### PR TITLE
Move systemd service file from main CoreDNS README

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,4 @@
+# Systemd Service File
+
+Use `coredns.service` as a systemd service file. It defaults to a coredns with a homedir of `/home/coredns`
+and the binary lives in `/opt/bin` and the config in `/etc/coredns/Corefile`.

--- a/systemd/coredns.service
+++ b/systemd/coredns.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=CoreDNS DNS server
+Documentation=https://coredns.io
+After=network.target
+
+[Service]
+PermissionsStartOnly=true
+LimitNOFILE=8192
+User=coredns
+WorkingDirectory=/home/coredns
+ExecStartPre=/sbin/setcap cap_net_bind_service=+ep /opt/bin/coredns
+ExecStart=/opt/bin/coredns -conf=/etc/coredns/Corefile
+ExecReload=/bin/kill -SIGUSR1 $MAINPID
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
@miekg take a look. I think we should remove that section from main README and instead point people to this repo.