### PR TITLE
debian: get latest release from github

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Build the debian packages
 .PHONY: debian
 debian:
-	dpkg-buildpackage -us -uc -b --target-arch amd64   
+	dpkg-buildpackage -us -uc -b --target-arch amd64
 	dpkg-buildpackage -us -uc -b --target-arch armhf
 	dpkg-buildpackage -us -uc -b --target-arch arm64
 	# debs are one up

--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
 Source: coredns
 Maintainer: Miek Gieben <miek@coredns.io>
-Build-Depends: debhelper (>= 9), ca-certificates, wget, dh-systemd, lsb-release
+Build-Depends: debhelper (>= 9), ca-certificates, curl, dh-systemd, lsb-release, jq
 
 Package: coredns
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -1,6 +1,10 @@
 #!/usr/bin/make -f
 
-VERSION := 0.9.10
+VERSION := $(shell curl -s https://api.github.com/repos/coredns/coredns/releases/latest  | jq -r '.tag_name[1:length]')
+# Github is ratelimiting this API pretty aggresively, default to something sane when null is returned.
+ifeq ($(VERSION),null)
+    $(error No version found)
+endif
 
 DEB_HOST_ARCH   := $(DEB_TARGET_ARCH)
 DISTRIBUTION    := $(shell lsb_release -sr)
@@ -26,7 +30,7 @@ override_dh_auto_clean:
 override_dh_auto_test:
 override_dh_auto_build:
 override_dh_auto_install:
-	wget -N --progress=dot:mega $(URL)
+	curl -L $(URL) -o $(TARBALL)
 	mkdir -p debian/coredns/usr/bin debian/coredns/etc/coredns
 	tar -xf $(TARBALL) -C debian/coredns/usr/bin
 	cp debian/Corefile debian/coredns/etc/coredns/Corefile

--- a/debian/rules
+++ b/debian/rules
@@ -1,7 +1,7 @@
 #!/usr/bin/make -f
 
 VERSION := $(shell curl -s https://api.github.com/repos/coredns/coredns/releases/latest  | jq -r '.tag_name[1:length]')
-# Github is ratelimiting this API pretty aggresively, default to something sane when null is returned.
+# Github is ratelimiting this API pretty aggresively, error when not set.
 ifeq ($(VERSION),null)
     $(error No version found)
 endif


### PR DESCRIPTION
Can do the same for homebrew and kubernetes - but it requires `jq` to be installed.