### PR TITLE
k8s: remove deprecated label

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -62,7 +62,6 @@ metadata:
   namespace: kube-system
   labels:
     k8s-app: coredns
-    kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
 spec:
   replicas: 1


### PR DESCRIPTION
Pointed out in #13, the label is deprecated.
It is also not present in kube-adm's version of the manifest.