### PR TITLE
kubernetes: fix pull policy 

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -83,7 +83,7 @@ spec:
       containers:
       - name: coredns
         image: coredns/coredns:1.0.1
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         args: [ "-conf", "/etc/coredns/Corefile" ]
         volumeMounts:
         - name: config-volume


### PR DESCRIPTION
Pull policy of IfNotPresent makes more sense when pointing to a static version tag.