### PR TITLE
kubernetes:  add pods insecure

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -51,6 +51,7 @@ data:
         log
         health
         kubernetes CLUSTER_DOMAIN SERVICE_CIDR POD_CIDR {
+          pods insecure
           upstream /etc/resolv.conf
         }
         prometheus :9153


### PR DESCRIPTION
Add `pods insecure` for feature parity with deprecated behavior of kube-dns.

see: #37