### PR TITLE
kubernetes:  no query logging, don't expose metrics at service

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -48,7 +48,6 @@ data:
   Corefile: |
     .:53 {
         errors
-        log
         health
         kubernetes CLUSTER_DOMAIN SERVICE_CIDR POD_CIDR {
           pods insecure
@@ -98,9 +97,6 @@ spec:
         - containerPort: 53
           name: dns-tcp
           protocol: TCP
-        - containerPort: 9153
-          name: metrics
-          protocol: TCP
         livenessProbe:
           httpGet:
             path: /health
@@ -138,7 +134,4 @@ spec:
     protocol: UDP
   - name: dns-tcp
     port: 53
-    protocol: TCP
-  - name: metrics
-    port: 9153
     protocol: TCP


### PR DESCRIPTION

Per-query logging not advisable as a production default.
Metrics dont need to be exposed on the service (becomes meaningless when replicas > 1).
