### PR TITLE
kubernetes: add cidr default, move to  getopts

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -50,7 +50,7 @@ data:
         errors
         log
         health
-        kubernetes CLUSTER_DOMAIN SERVICE_CIDR POD_CIDR {
+        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
           pods insecure
           upstream /etc/resolv.conf
         }

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -2,18 +2,47 @@
 
 # Deploys CoreDNS to a cluster currently running Kube-DNS.
 
-SERVICE_CIDR=$1
-POD_CIDR=$2
-CLUSTER_DNS_IP=$3
-CLUSTER_DOMAIN=${4:-cluster.local}
-YAML_TEMPLATE=${5:-`pwd`/coredns.yaml.sed}
+show_help () {
+cat << EOF
+usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ]
 
-if [[ -z $SERVICE_CIDR ]]; then
-	echo "Usage: $0 SERVICE-CIDR [ POD-CIDR ] [ DNS-IP ] [ CLUSTER-DOMAIN ] [ YAML-TEMPLATE ]"
-	exit 1
+    -r : Define a reverse zone for the given CIDR. You may specifcy this option more
+         than once to add multiple reverse zones. If no reverse CIDRs are defined,
+         then the default is to handle all reverse zones (i.e. 0.0.0.0/0)
+    -i : Specify the cluster DNS IP address. If not specificed, the IP address of
+         the existing "kube-dns" service is used, if present.
+EOF
+exit 0
+}
+
+# Simple Defaults
+CLUSTER_DOMAIN=cluster.local
+YAML_TEMPLATE=`pwd`/coredns.yaml.sed
+
+
+# Get Opts
+while getopts "hr:i:d:t:" opt; do
+    case "$opt" in
+    h)
+        show_help
+        ;;
+    r)  REVERSE_CIDRS="$REVERSE_CIDRS $OPTARG"
+        ;;
+    i)  CLUSTER_DNS_IP=$OPTARG
+        ;;
+    d)  CLUSTER_DOMAIN=$OPTARG
+        ;;
+    t)  YAML_TEMPLATE=$OPTARG
+        ;;
+    esac
+done
+
+# Conditional Defaults
+if [[ -z $REVERSE_CIDRS ]]; then
+  REVERSE_CIDRS=0.0.0.0/0
 fi
-
 if [[ -z $CLUSTER_DNS_IP ]]; then
+  # Default IP to kube-dns IP
   CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system kube-dns -o jsonpath="{.spec.clusterIP}")
   if [ $? -ne 0 ]; then
       >&2 echo "Error! The IP address for DNS service couldn't be determined automatically. Please specify the DNS-IP in paramaters."
@@ -21,4 +50,4 @@ if [[ -z $CLUSTER_DNS_IP ]]; then
   fi
 fi
 
-sed -e s/CLUSTER_DNS_IP/$CLUSTER_DNS_IP/g -e s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g -e s?SERVICE_CIDR?$SERVICE_CIDR?g -e s?POD_CIDR?$POD_CIDR?g $YAML_TEMPLATE
+sed -e s/CLUSTER_DNS_IP/$CLUSTER_DNS_IP/g -e s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g -e "s?REVERSE_CIDRS?$REVERSE_CIDRS?g" $YAML_TEMPLATE


### PR DESCRIPTION
This change makes the default CIDR range 0.0.0.0/0 - configuring the kubernetes plugin to handle all reverse zones. 

The list of unlabeled/optional options was becoming unwieldy, so I also moved the script to use getopts.

As a result, the usage has changed ...
```
$ ./deploy.sh -h
usage: ./deploy.sh [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ]

    -r : Define a reverse zone for the given CIDR. You may specifcy this option more
         than once to add multiple reverse zones. If no reverse CIDRs are defined,
         then the default is to handle all reverse zones (i.e. 0.0.0.0/0)
    -i : Specify the cluster DNS IP address. If not specificed, the IP address of
         the existing "kube-dns" service is used, if present.
```

_This will require updates to the integration script which executes deploy.sh._

As documented, the `-r` option can be given more than once, allowing a service CIDR and multiple disjointed pod CIDRs if needed.  Note that there are no longer separate "service" and "pod" cidr parameters, since there is no need to distinguish them from one another. 