### PR TITLE
kubernetes: Reverse zone fall through

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -21,10 +21,10 @@ You should examine the manifest carefully and make sure it is correct for your p
 cluster. Depending on how you have built your cluster and the version you are running,
 some modifications to the manifest may be needed.
 
-In the best case scenario, all that's needed to replace Kube-DNS are these two commands (replacing the CIDRs with the service and pod CIDRs in your deployment respectively):
+In the best case scenario, all that's needed to replace Kube-DNS are these two commands:
 
 ~~~
-$ ./deploy.sh 10.3.0.0/12 172.17.0.0/16 | kubectl apply -f -
+$ ./deploy.sh | kubectl apply -f -
 $ kubectl delete --namespace=kube-system deployment kube-dns
 ~~~
 

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -49,7 +49,7 @@ data:
     .:53 {
         errors
         health
-        kubernetes CLUSTER_DOMAIN SERVICE_CIDR POD_CIDR {
+        kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
           pods insecure
           upstream /etc/resolv.conf
         }

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -52,6 +52,7 @@ data:
         kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
           pods insecure
           upstream /etc/resolv.conf
+          fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
         proxy . /etc/resolv.conf

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -2,18 +2,47 @@
 
 # Deploys CoreDNS to a cluster currently running Kube-DNS.
 
-SERVICE_CIDR=$1
-POD_CIDR=$2
-CLUSTER_DNS_IP=$3
-CLUSTER_DOMAIN=${4:-cluster.local}
-YAML_TEMPLATE=${5:-`pwd`/coredns.yaml.sed}
+show_help () {
+cat << EOF
+usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ]
 
-if [[ -z $SERVICE_CIDR ]]; then
-	echo "Usage: $0 SERVICE-CIDR [ POD-CIDR ] [ DNS-IP ] [ CLUSTER-DOMAIN ] [ YAML-TEMPLATE ]"
-	exit 1
+    -r : Define a reverse zone for the given CIDR. You may specifcy this option more
+         than once to add multiple reverse zones. If no reverse CIDRs are defined,
+         then the default is to handle all reverse zones (i.e. 0.0.0.0/0)
+    -i : Specify the cluster DNS IP address. If not specificed, the IP address of
+         the existing "kube-dns" service is used, if present.
+EOF
+exit 0
+}
+
+# Simple Defaults
+CLUSTER_DOMAIN=cluster.local
+YAML_TEMPLATE=`pwd`/coredns.yaml.sed
+
+
+# Get Opts
+while getopts "hr:i:d:t:" opt; do
+    case "$opt" in
+    h)
+        show_help
+        ;;
+    r)  REVERSE_CIDRS="$REVERSE_CIDRS $OPTARG"
+        ;;
+    i)  CLUSTER_DNS_IP=$OPTARG
+        ;;
+    d)  CLUSTER_DOMAIN=$OPTARG
+        ;;
+    t)  YAML_TEMPLATE=$OPTARG
+        ;;
+    esac
+done
+
+# Conditional Defaults
+if [[ -z $REVERSE_CIDRS ]]; then
+  REVERSE_CIDRS=0.0.0.0/0
 fi
-
 if [[ -z $CLUSTER_DNS_IP ]]; then
+  # Default IP to kube-dns IP
   CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system kube-dns -o jsonpath="{.spec.clusterIP}")
   if [ $? -ne 0 ]; then
       >&2 echo "Error! The IP address for DNS service couldn't be determined automatically. Please specify the DNS-IP in paramaters."
@@ -21,4 +50,4 @@ if [[ -z $CLUSTER_DNS_IP ]]; then
   fi
 fi
 
-sed -e s/CLUSTER_DNS_IP/$CLUSTER_DNS_IP/g -e s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g -e s?SERVICE_CIDR?$SERVICE_CIDR?g -e s?POD_CIDR?$POD_CIDR?g $YAML_TEMPLATE
+sed -e s/CLUSTER_DNS_IP/$CLUSTER_DNS_IP/g -e s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g -e "s?REVERSE_CIDRS?$REVERSE_CIDRS?g" $YAML_TEMPLATE

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -3,15 +3,15 @@
 # Deploys CoreDNS to a cluster currently running Kube-DNS.
 
 show_help () {
-cat << EOF
+cat << USAGE
 usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ]
 
     -r : Define a reverse zone for the given CIDR. You may specifcy this option more
          than once to add multiple reverse zones. If no reverse CIDRs are defined,
-         then the default is to handle all reverse zones (i.e. 0.0.0.0/0)
+         then the default is to handle all reverse zones (i.e. in-addr.arpa and ip6.arpa)
     -i : Specify the cluster DNS IP address. If not specificed, the IP address of
          the existing "kube-dns" service is used, if present.
-EOF
+USAGE
 exit 0
 }
 
@@ -23,8 +23,7 @@ YAML_TEMPLATE=`pwd`/coredns.yaml.sed
 # Get Opts
 while getopts "hr:i:d:t:" opt; do
     case "$opt" in
-    h)
-        show_help
+    h)  show_help
         ;;
     r)  REVERSE_CIDRS="$REVERSE_CIDRS $OPTARG"
         ;;
@@ -39,13 +38,13 @@ done
 
 # Conditional Defaults
 if [[ -z $REVERSE_CIDRS ]]; then
-  REVERSE_CIDRS=0.0.0.0/0
+  REVERSE_CIDRS="in-addr.arpa ip6.arpa"
 fi
 if [[ -z $CLUSTER_DNS_IP ]]; then
   # Default IP to kube-dns IP
   CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system kube-dns -o jsonpath="{.spec.clusterIP}")
   if [ $? -ne 0 ]; then
-      >&2 echo "Error! The IP address for DNS service couldn't be determined automatically. Please specify the DNS-IP in paramaters."
+      >&2 echo "Error! The IP address for DNS service couldn't be determined automatically. Please specify the DNS-IP with the '-i' option."
       exit 2
   fi
 fi


### PR DESCRIPTION

- Add reverse zone fall through to config.
- Move to flag based parameters (the string of all optional parameters was getting clumsy).