### PR TITLE
kubernetes: Upstream to self

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -51,7 +51,7 @@ data:
         health
         kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
           pods insecure
-          upstream /etc/resolv.conf
+          upstream LOCALHOST_IP
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -4,13 +4,14 @@
 
 show_help () {
 cat << USAGE
-usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ]
+usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ] [ -6 ]
 
     -r : Define a reverse zone for the given CIDR. You may specifcy this option more
          than once to add multiple reverse zones. If no reverse CIDRs are defined,
          then the default is to handle all reverse zones (i.e. in-addr.arpa and ip6.arpa)
     -i : Specify the cluster DNS IP address. If not specificed, the IP address of
          the existing "kube-dns" service is used, if present.
+    -6 : Deploy for IPv6 only pod network environment
 USAGE
 exit 0
 }
@@ -18,10 +19,10 @@ exit 0
 # Simple Defaults
 CLUSTER_DOMAIN=cluster.local
 YAML_TEMPLATE=`pwd`/coredns.yaml.sed
-
+LOCALHOST_IP=127.0.0.1:53
 
 # Get Opts
-while getopts "hr:i:d:t:" opt; do
+while getopts "hr:i:d:t:6" opt; do
     case "$opt" in
     h)  show_help
         ;;
@@ -32,6 +33,8 @@ while getopts "hr:i:d:t:" opt; do
     d)  CLUSTER_DOMAIN=$OPTARG
         ;;
     t)  YAML_TEMPLATE=$OPTARG
+        ;;
+    6)  LOCALHOST_IP=[::1]:53
         ;;
     esac
 done
@@ -49,4 +52,4 @@ if [[ -z $CLUSTER_DNS_IP ]]; then
   fi
 fi
 
-sed -e s/CLUSTER_DNS_IP/$CLUSTER_DNS_IP/g -e s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g -e "s?REVERSE_CIDRS?$REVERSE_CIDRS?g" $YAML_TEMPLATE
+sed -e s/CLUSTER_DNS_IP/$CLUSTER_DNS_IP/g -e s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g -e "s?REVERSE_CIDRS?$REVERSE_CIDRS?g" -e "s?LOCALHOST_IP?$LOCALHOST_IP?g" $YAML_TEMPLATE


### PR DESCRIPTION
Change upstream to reference self - i.e. resolve CNAMEs by calling self on localhost.
Provide an ipv6 option for ipv6 pod environments.

The need for this came to light when exploring how stub-domains work in kube-dns, and how to translate them into coredns configuration.  For direct `A` and `AAAA` record lookups, coredns can represent stub-domains using multiple `proxy` plugins. However, resolution of `CNAME` targets occurs based on the `upstream` option, which cannot mimic kube-dns stub-domains.  But if we self reference in the `upstream` option, then the query re-enters the chain, and can resolve properly via `proxy` plugin.