### PR TITLE
kubernetes: remove pod anti affinity

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -85,18 +85,6 @@ spec:
       tolerations:
         - key: "CriticalAddonsOnly"
           operator: "Exists"
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: k8s-app
-                  operator: In
-                  values:
-                  - coredns
-              topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
         image: coredns/coredns:1.0.4


### PR DESCRIPTION
Scalability woes persist for pod anti-affinity in kubernetes.
See kubernetes/kubernetes#54164 re-opened recently, and kubernetes/kubernetes#57683 reverted by kubernetes/kubernetes#59357.