### PR TITLE
Systemd sysusers directory

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -3,3 +3,7 @@
 Use `coredns.service` as a systemd service file. It defaults to using a "coredns" user with
 a homedir of `/var/lib/coredns` and the binary lives in `/usr/bin` and the config in
 `/etc/coredns/Corefile`.
+
+In order to work, the systemd unit needs a user named `coredns`, an handy way to provide
+it is to use the `systemd-sysusers` service by installing the `coredns-sysusers.conf` file in the
+`sysusers.d` folder (e.g: `/usr/lib/sysusers.d`).

--- a/systemd/coredns-sysusers.conf
+++ b/systemd/coredns-sysusers.conf
@@ -1,0 +1,1 @@
+u coredns - "CoreDNS is a DNS server that chains plugins " /

--- a/systemd/coredns.service
+++ b/systemd/coredns.service
@@ -7,9 +7,9 @@ After=network.target
 PermissionsStartOnly=true
 LimitNOFILE=1048576
 LimitNPROC=512
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE 
-AmbientCapabilities=CAP_NET_BIND_SERVICE 
-NoNewPrivileges=true 
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
 User=coredns
 WorkingDirectory=~
 ExecStart=/usr/bin/coredns -conf=/etc/coredns/Corefile


### PR DESCRIPTION
This PR adds the systemd-sysusers specification for the coredns systemd service.
I think that this needs to stay in this repo so that packagers/users can just download the "official" systemd unit along with the user specification.

I'm already using this in the `coredns` and `coredns-bin` aur packages but think that would be useful to have this here with the unit instead of commiting it in the aur package itself.

This is not arch specific but belongs to any distro using systemd.

Signed-off-by: Lorenzo Fontana <lo@linux.com>