### PR TITLE
Keep manifest consistent with kubeadm

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -29,6 +29,9 @@ $ ./deploy.sh | kubectl apply -f -
 $ kubectl delete --namespace=kube-system deployment kube-dns
 ~~~
 
+NOTE: It is recommended to delete the kube-dns depployment else if both CoreDNS and kube-dns are running, queries may randomly hit either
+CoreDNS or kube-dns.
+
 For non-RBAC deployments, you'll need to edit the resulting yaml before applying it:
 1. Remove the line `serviceAccountName: coredns` from the `Deployment` section.
 2. Remove the `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` sections.

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -65,7 +65,7 @@ metadata:
   name: coredns
   namespace: kube-system
   labels:
-    k8s-app: coredns
+    k8s-app: kube-dns
     kubernetes.io/name: "CoreDNS"
 spec:
   replicas: 2
@@ -75,11 +75,11 @@ spec:
       maxUnavailable: 1
   selector:
     matchLabels:
-      k8s-app: coredns
+      k8s-app: kube-dns
   template:
     metadata:
       labels:
-        k8s-app: coredns
+        k8s-app: kube-dns
     spec:
       serviceAccountName: coredns
       tolerations:
@@ -129,12 +129,12 @@ metadata:
   annotations:
     prometheus.io/scrape: "true"
   labels:
-    k8s-app: coredns
+    k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
 spec:
   selector:
-    k8s-app: coredns
+    k8s-app: kube-dns
   clusterIP: CLUSTER_DNS_IP
   ports:
   - name: dns


### PR DESCRIPTION
Changing the k8s-app label to kube-dns, as defined in coredns manifest in kubernetes.