### PR TITLE
kubernetes: reload config

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -57,6 +57,7 @@ data:
         prometheus :9153
         proxy . /etc/resolv.conf
         cache 30
+        reload
     }
 ---
 apiVersion: extensions/v1beta1


### PR DESCRIPTION
add reload.

is the default interval OK?

In kubernetes there is a delay for pod mounts to see configmap changes. This is caused by kubelet sync frequency, which defaults to 1 minute + ttl of configmap in kubelet cache which is also a minute).  So, it can be up to two minutes in a typical k8s deployment.