### PR TITLE
Drop unneeded capabilities, make container read-only

### DIFF
--- a/docker/dns.yml
+++ b/docker/dns.yml
@@ -9,7 +9,12 @@ services:
       - "53:53/tcp"
       - "9153:9153/tcp"
     volumes:
-      - coredns:/data
+      - coredns:/data:ro
+    cap_drop:
+      - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+    read_only: true
     deploy:
       mode: global
       placement:

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -94,6 +94,7 @@ spec:
         volumeMounts:
         - name: config-volume
           mountPath: /etc/coredns
+          readOnly: true
         ports:
         - containerPort: 53
           name: dns
@@ -104,6 +105,14 @@ spec:
         - containerPort: 9153
           name: metrics
           protocol: TCP
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            add:
+            - NET_BIND_SERVICE
+            drop:
+            - all
+          readOnlyRootFilesystem: true
         livenessProbe:
           httpGet:
             path: /health


### PR DESCRIPTION
Whether or not coredns/coredns#1767 is done in the container, it should at least be done in orchestration because of separation of concerns. 