### PR TITLE
add resources for kubernetes deployment

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -90,8 +90,13 @@ spec:
       containers:
       - name: coredns
         image: coredns/coredns:1.2.0
-        imagePullPolicy: IfNotPresent
         args: [ "-conf", "/etc/coredns/Corefile" ]
+        # TODO: These resources are generic value for generic deployment.
+        # please adjust it according to you size and expected load.
+        resources:
+          requests:
+            cpu: 100m
+            memory: 70Mi
         volumeMounts:
         - name: config-volume
           mountPath: /etc/coredns


### PR DESCRIPTION
Resources should be set for all deployments because Kubernetes scheduler needs to
know resource requirements for pods. Any definition is better than
nothing.

Does anybody have measurement of resource usage for coredns? These values (100m, 70Mi) are just generic values.