### PR TITLE
Add kubeconfig option

### DIFF
--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -4,7 +4,7 @@
 
 show_help () {
 cat << USAGE
-usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ]
+usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ] [ -k KUBECONFIG ]
 
     -r : Define a reverse zone for the given CIDR. You may specifcy this option more
          than once to add multiple reverse zones. If no reverse CIDRs are defined,
@@ -21,7 +21,7 @@ YAML_TEMPLATE=`pwd`/coredns.yaml.sed
 
 
 # Get Opts
-while getopts "hr:i:d:t:" opt; do
+while getopts "hr:i:d:t:k:" opt; do
     case "$opt" in
     h)  show_help
         ;;
@@ -33,16 +33,26 @@ while getopts "hr:i:d:t:" opt; do
         ;;
     t)  YAML_TEMPLATE=$OPTARG
         ;;
+    k)  KUBECONFIG=$OPTARG
+        ;;
     esac
 done
 
+# Set kubeconfig flag if config specified
+if [[ ! -z $KUBECONFIG ]]; then
+  if [[ -f $KUBECONFIG ]]; then
+    KUBECONFIG="--kubeconfig $KUBECONFIG"
+  else
+    KUBECONFIG=""
+  fi
+fi
 # Conditional Defaults
 if [[ -z $REVERSE_CIDRS ]]; then
   REVERSE_CIDRS="in-addr.arpa ip6.arpa"
 fi
 if [[ -z $CLUSTER_DNS_IP ]]; then
   # Default IP to kube-dns IP
-  CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system kube-dns -o jsonpath="{.spec.clusterIP}")
+  CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system kube-dns -o jsonpath="{.spec.clusterIP}" $KUBECONFIG)
   if [ $? -ne 0 ]; then
       >&2 echo "Error! The IP address for DNS service couldn't be determined automatically. Please specify the DNS-IP with the '-i' option."
       exit 2


### PR DESCRIPTION
Add an option to specify a kubeconfig, in case it is needed to retrieve the kube-dns service IP.