### PR TITLE
Add kube-dns to CoreDNS configmap translation

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -22,6 +22,9 @@ it creates a ConfigMap and a CoreDNS deployment, then updates the Kube-DNS servi
 to use the CoreDNS deployment. By re-using the existing service, there is no disruption in
 servicing requests.
 
+By default, the deployment script also translates the existing kube-dns configuration into the equivalent CoreDNS Corefile.
+By providing the `-s` option, the deployment script will skip the translation of the ConfigMap from kube-dns to CoreDNS.
+
 The script doesn't delete the kube-dns deployment or replication controller - you'll have to
 do that manually, after deploying CoreDNS.
 
@@ -29,7 +32,7 @@ You should examine the manifest carefully and make sure it is correct for your p
 cluster. Depending on how you have built your cluster and the version you are running,
 some modifications to the manifest may be needed.
 
-In the best case scenario, all that's needed to replace Kube-DNS are these two commands:
+In the best case scenario, all that's needed to replace Kube-DNS are these commands:
 
 ~~~
 $ ./deploy.sh | kubectl apply -f -

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -53,13 +53,13 @@ data:
           pods insecure
           upstream
           fallthrough in-addr.arpa ip6.arpa
-        }
+        }FEDERATIONS
         prometheus :9153
-        proxy . /etc/resolv.conf
+        proxy . UPSTREAMNAMESERVER
         cache 30
         reload
         loadbalance
-    }
+    }STUBDOMAINS
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -11,6 +11,8 @@ usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMP
          then the default is to handle all reverse zones (i.e. in-addr.arpa and ip6.arpa)
     -i : Specify the cluster DNS IP address. If not specificed, the IP address of
          the existing "kube-dns" service is used, if present.
+    -s : Skips the translation of kube-dns configmap to the corresponding CoreDNS Corefile configuration.
+
 USAGE
 exit 0
 }
@@ -18,12 +20,76 @@ exit 0
 # Simple Defaults
 CLUSTER_DOMAIN=cluster.local
 YAML_TEMPLATE=`pwd`/coredns.yaml.sed
+STUBDOMAINS=""
+UPSTREAM=\\/etc\\/resolv\.conf
+FEDERATIONS=""
+
+
+# Translates the kube-dns ConfigMap to equivalent CoreDNS Configuration.
+function translate-kube-dns-configmap {
+    kube-dns-federation-to-coredns
+    kube-dns-upstreamnameserver-to-coredns
+    kube-dns-stubdomains-to-coredns
+}
+
+function kube-dns-federation-to-coredns {
+  fed=$(kubectl -n kube-system get configmap kube-dns  -ojsonpath='{.data.federations}' 2> /dev/null | jq . | tr -d '":,')
+  if [[ ! -z ${fed} ]]; then
+  FEDERATIONS=$(sed -e '1s/^/federation /' -e 's/^/        /' -e '1i\\' <<< "${fed}") # add federation to the stanza
+  fi
+}
+
+function kube-dns-upstreamnameserver-to-coredns {
+  up=$(kubectl -n kube-system get configmap kube-dns  -ojsonpath='{.data.upstreamNameservers}' 2> /dev/null | tr -d '[",]')
+  if [[ ! -z ${up} ]]; then
+    UPSTREAM=${up}
+  fi
+}
+
+function kube-dns-stubdomains-to-coredns {
+  STUBDOMAIN_TEMPLATE='
+    SD_DOMAIN:53 {
+      errors
+      cache 30
+      proxy . SD_DESTINATION
+    }'
+
+  function dequote {
+    str=${1#\"} # delete leading quote
+    str=${str%\"} # delete trailing quote
+    echo ${str}
+  }
+
+  function parse_stub_domains() {
+    sd=$1
+
+  # get keys - each key is a domain
+  sd_keys=$(echo -n $sd | jq keys[])
+
+  # For each domain ...
+  for dom in $sd_keys; do
+    dst=$(echo -n $sd | jq '.['$dom'][0]') # get the destination
+
+    dom=$(dequote $dom)
+    dst=$(dequote $dst)
+
+    sd_stanza=${STUBDOMAIN_TEMPLATE/SD_DOMAIN/$dom} # replace SD_DOMAIN
+    sd_stanza=${sd_stanza/SD_DESTINATION/$dst} # replace SD_DESTINATION
+    echo "$sd_stanza"
+  done
+}
+
+  sd=$(kubectl -n kube-system get configmap kube-dns  -ojsonpath='{.data.stubDomains}' 2> /dev/null)
+  STUBDOMAINS=$(parse_stub_domains "$sd")
+}
 
 
 # Get Opts
-while getopts "hr:i:d:t:k:" opt; do
+while getopts "hsr:i:d:t:k:" opt; do
     case "$opt" in
     h)  show_help
+        ;;
+    s)  SKIP=1
         ;;
     r)  REVERSE_CIDRS="$REVERSE_CIDRS $OPTARG"
         ;;
@@ -59,4 +125,16 @@ if [[ -z $CLUSTER_DNS_IP ]]; then
   fi
 fi
 
-sed -e s/CLUSTER_DNS_IP/$CLUSTER_DNS_IP/g -e s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g -e "s?REVERSE_CIDRS?$REVERSE_CIDRS?g" $YAML_TEMPLATE
+if [[ "${SKIP}" -ne 1 ]] ; then
+    translate-kube-dns-configmap
+fi
+
+orig=$'\n'
+replace=$'\\\n'
+sed -e "s/CLUSTER_DNS_IP/$CLUSTER_DNS_IP/g" \
+    -e "s/CLUSTER_DOMAIN/$CLUSTER_DOMAIN/g" \
+    -e "s?REVERSE_CIDRS?$REVERSE_CIDRS?g" \
+    -e "s@STUBDOMAINS@${STUBDOMAINS//$orig/$replace}@g" \
+    -e "s@FEDERATIONS@${FEDERATIONS//$orig/$replace}@g" \
+    -e "s/UPSTREAMNAMESERVER/$UPSTREAM/g" \
+    ${YAML_TEMPLATE}


### PR DESCRIPTION
This adds the configmap translation from kube-dns to CoreDNS.
Users can deploy and apply the translation by specifying the `-u` flag.

@chrisohaver @fturib PTAL