### PR TITLE
Rollback to kube-dns

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -41,3 +41,21 @@ $ kubectl delete --namespace=kube-system deployment kube-dns
 For non-RBAC deployments, you'll need to edit the resulting yaml before applying it:
 1. Remove the line `serviceAccountName: coredns` from the `Deployment` section.
 2. Remove the `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` sections.
+
+
+## Rollback to kube-dns
+
+In case one wants to revert a Kubernetes cluster running CoreDNS back to kube-dns,
+the `rollback.sh` script generates the kube-dns manifest to install kube-dns.
+This uses the existing service, there is no disruption in servicing requests.
+
+The script doesn't delete the CoreDNS deployment or replication controller - you'll have to
+do that manually, after deploying kube-dns.
+
+These commands will deploy kube-dns replacing CoreDNS:
+~~~
+$ ./rollback.sh | kubectl apply -f -
+$ kubectl delete --namespace=kube-system deployment coredns
+~~~
+
+**NOTE:** You will need to delete the CoreDNS deployment (as above) since while CoreDNS and kube-dns are running at the same time, queries may randomly hit either one.

--- a/kubernetes/rollback.sh
+++ b/kubernetes/rollback.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Roll back kube-dns to the cluster which has CoreDNS installed.
+
+show_help () {
+cat << USAGE
+usage: $0  [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ]
+
+    -i : Specify the cluster DNS IP address. If not specificed, the IP address of
+         the existing "kube-dns" service is used, if present.
+    -d : Specify the Cluster Domain. Default is "cluster.local"
+USAGE
+exit 0
+}
+
+
+curl -L  https://raw.githubusercontent.com/kubernetes/kubernetes/master/cluster/addons/dns/kube-dns/kube-dns.yaml.base > `pwd`/kube-dns.yaml.sed
+
+# Simple Defaults
+CLUSTER_DOMAIN=cluster.local
+YAML_TEMPLATE=`pwd`/kube-dns.yaml.sed
+
+
+# Get Opts
+while getopts "hi:d:" opt; do
+    case "$opt" in
+    h)  show_help
+        ;;
+    i)  CLUSTER_DNS_IP=$OPTARG
+        ;;
+    d)  CLUSTER_DOMAIN=$OPTARG
+        ;;
+    esac
+done
+
+
+if [[ -z $CLUSTER_DNS_IP ]]; then
+  # Default IP to kube-dns IP
+  CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system kube-dns -o jsonpath="{.spec.clusterIP}")
+  if [ $? -ne 0 ]; then
+      >&2 echo "Error! The IP address for DNS service couldn't be determined automatically. Please specify the DNS-IP with the '-i' option."
+      exit 2
+  fi
+fi
+
+sed -e s/__PILLAR__DNS__SERVER__/${CLUSTER_DNS_IP}/g -e s/__PILLAR__DNS__DOMAIN__/${CLUSTER_DOMAIN}/g ${YAML_TEMPLATE}


### PR DESCRIPTION
Rollback script to deploy kube-dns in a Kubernetes cluster running CoreDNS