### PR TITLE
kubernetes: move coredns pods to 10053, and redirect service

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -46,7 +46,7 @@ metadata:
   namespace: kube-system
 data:
   Corefile: |
-    .:53 {
+    .:10053 {
         errors
         health
         kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
@@ -105,10 +105,10 @@ spec:
           mountPath: /etc/coredns
           readOnly: true
         ports:
-        - containerPort: 53
+        - containerPort: 10053
           name: dns
           protocol: UDP
-        - containerPort: 53
+        - containerPort: 10053
           name: dns-tcp
           protocol: TCP
         - containerPort: 9153
@@ -117,8 +117,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
-            add:
-            - NET_BIND_SERVICE
             drop:
             - all
           readOnlyRootFilesystem: true
@@ -160,6 +158,8 @@ spec:
   - name: dns
     port: 53
     protocol: UDP
+    targetPort: 10053
   - name: dns-tcp
     port: 53
     protocol: TCP
+    targetPort: 10053


### PR DESCRIPTION
move coredns pods from 53 to 10053
redirect service 53 -> 10053
remove net_bind_service capability requirement