### PR TITLE
k8s: bump to 1.2.2, restore mem limit to 170

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -92,11 +92,11 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:1.2.1
+        image: coredns/coredns:1.2.2
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            memory: 320Mi
+            memory: 170Mi
           requests:
             cpu: 100m
             memory: 70Mi


### PR DESCRIPTION
bump version to 1.2.2
restore mem limit to prior number, since cache max is smaller by default now in 1.2.2