### PR TITLE
Add getting nodes permission to system:coredns clusterrole

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -21,6 +21,12 @@ rules:
   verbs:
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding


### PR DESCRIPTION
`coredns` when using federation plugin accesses the nodes to fetch zone and region labels. it would fail to get nodes if the `system:coredns` does not permission to get nodes and hence this pr.

/cc @chrisohaver @johnbelamaric 