### PR TITLE
Bump version to 1.2.4 and update deployment

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -96,9 +96,11 @@ spec:
           effect: NoSchedule
         - key: "CriticalAddonsOnly"
           operator: "Exists"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - name: coredns
-        image: coredns/coredns:1.2.2
+        image: coredns/coredns:1.2.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
Version updated to 1.2.4 and update the deployment to ensure CoreDNS containers binds to linux nodes