### PR TITLE
Bind coredns containers to linux nodes to avoid scheduling on Windows

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -96,6 +96,8 @@ spec:
           effect: NoSchedule
         - key: "CriticalAddonsOnly"
           operator: "Exists"
+      nodeSelector:
+        beta.kubernetes.io/os: linux
       containers:
       - name: coredns
         image: coredns/coredns:1.2.2


### PR DESCRIPTION
Pursuant to https://github.com/kubernetes/kubernetes/issues/69773
