### PR TITLE
Add metrics port 9153 to Service, to match Pod ports

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -170,3 +170,6 @@ spec:
   - name: dns-tcp
     port: 53
     protocol: TCP
+  - name: metrics
+    port: 9153
+    protocol: TCP


### PR DESCRIPTION
Add port `9153` named `metrics` to the `kube-dns` service. This isn't strictly necessary but is nice to have it aligned with the ports on the Pods. See also: https://github.com/coredns/deployment/pull/80/files

This addresses https://github.com/coreos/prometheus-operator/pull/2149#discussion_r235437007 in the kube-prometheus monitoring configuration.