### PR TITLE
Add readinessProbe

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -138,6 +138,11 @@ spec:
           timeoutSeconds: 5
           successThreshold: 1
           failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
       dnsPolicy: Default
       volumes:
         - name: config-volume


### PR DESCRIPTION
Adding a readinessProbe using the health plugin, which should accurately represent readiness.
This prevents loadbalancing to unready pods, and also allows rolling updates to work as expected.