### PR TITLE
Add priority class

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -90,6 +90,7 @@ spec:
       labels:
         k8s-app: kube-dns
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:
         - key: "CriticalAddonsOnly"


### PR DESCRIPTION
Adds `priorityClassName` to give preference in scheduling CoreDNS pods over less critical pods.