### PR TITLE
Kubernetes Corefile Migration Tool

### DIFF
--- a/kubernetes/migration/README.md
+++ b/kubernetes/migration/README.md
@@ -12,6 +12,7 @@ This Go library provides a set of functions to help handle migrations of CoreDNS
   * replace/convert any plugins/directives that have replacements (e.g. _proxy_ -> _forward_)
   * return an error if replacable plugins/directives cannot be converted (e.g. proxy _options_ not available in _forward_)
   * remove plugins/directives that do not have replacements (e.g. kubernetes `upstream`)
+  * add in any new default plugins where applicable if they are not already present (e.g. adding _loop_ plugin when it was added).  This will have to be case by case, and could potentially get complicated.
   * if _deprecations_ is set to true, also migrate deprecated plugins/directives.
 
 `Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of plugins that are not recognized/supported by the migration tool (but may still be valid in CoreDNS).  We must handle all the default plugins, and we should make an effort to handle the most common non-default plugins. Each string returned is a warning, e.g. "plugin 'foo' is not supported by the migration tool." An empty list returned means there are no unsupported plugins/options present in the Corefile.
@@ -31,3 +32,14 @@ Usage:
   corefile-tool migrate --from <coredns-version> --to <coredns-version> --corefile <path>
   etc ...
 ```
+
+## Example of Usage
+
+This is an example of how these tools could be used by an installer/upgrader... 
+
+1. check Deprecated(), if anything is deprecated, warn user, but continue install. 
+2. check Unsupported(), if anything is unsupported, abort and warn user (allow user to override to pass this).
+3. call Migrate(), if there is an error, abort and warn user.
+4. If there is no error, and the starting Corefile was not a default, pause and ask user if they want to continue with the migration.  If the starting Corefile was at defaults, proceed use the migrated corefile.
+
+

--- a/kubernetes/migration/README.md
+++ b/kubernetes/migration/README.md
@@ -17,9 +17,9 @@ This Go library provides a set of functions to help handle migrations of CoreDNS
 
 `Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of plugins that are not recognized/supported by the migration tool (but may still be valid in CoreDNS).  We must handle all the default plugins, and we should make an effort to handle the most common non-default plugins. Each string returned is a warning, e.g. "plugin 'foo' is not supported by the migration tool." An empty list returned means there are no unsupported plugins/options present in the Corefile.
 
-`Default(fromK8sVersion, corefile string) boolean`: returns `true` if the Corefile is the default for a that version of Kubernetes.  If `fromK8sVersion` is omitted, returns `true` if the Corefile is the default for any version.  Some degree of safe fuzzy matching should be employed here to accept custom cluster domain names and IP addresses, as well as white space.
+`Default(fromK8sVersion, corefile string) bool`: returns `true` if the Corefile is the default for a that version of Kubernetes.  If `fromK8sVersion` is omitted, returns `true` if the Corefile is the default for any version.  Some degree of safe fuzzy matching should be employed here to accept custom cluster domain names and IP addresses, as well as white space.
 
-`CheckCorefile(coreDNSVersion, corefile string) error`: returns true if the configuration is valid for the given version.  This is intended as a sanity checks to make sure a Corefile can be loaded by CoreDNS, e.g. by calling `setup()` for each plugin used.  This won't work for custom compilations CoreDNS - e.g. one compiled with external plugins are used.
+`CheckCorefile(coreDNSVersion, corefile string) bool`: returns true if the configuration is valid for the given version.  This is intended as a sanity checks to make sure a Corefile can be loaded by CoreDNS, e.g. by calling `setup()` for each plugin used.  This won't work for custom compilations CoreDNS - e.g. one compiled with external plugins are used.
 
 `Released(dockerImageID string) bool`: returns `true` if `dockerImageID` matches any _released_ image of CoreDNS.
 

--- a/kubernetes/migration/README.md
+++ b/kubernetes/migration/README.md
@@ -23,6 +23,8 @@ This Go library provides a set of functions to help handle migrations of CoreDNS
 
 `Released(dockerImageID string) bool`: returns `true` if `dockerImageID` matches any _released_ image of CoreDNS. This includes all released verisons of CoreDNS, not just those associted with Kubernetes releases. 
 
+Globally, `toCoreDNSVersion` must always be higher than `fromCoreDNSVersion`.  Supporting downward migrations may be possible, but I don't think necessary to support at this time, so we should expressly forbid downward migrations for now.  That said, if a Corefile is at default then a downgrade is very easy (since no migration is required). It's up to the K8s installer to decide if they want to support that.
+
 
 ## Command Line Converter
 

--- a/kubernetes/migration/README.md
+++ b/kubernetes/migration/README.md
@@ -19,6 +19,11 @@ This Go library provides a set of functions to help handle migrations of CoreDNS
 
 `Default(fromK8sVersion, corefile string) boolean`: returns `true` if the Corefile is the default for a that version of Kubernetes.  If `fromK8sVersion` is omitted, returns `true` if the Corefile is the default for any version.  Some degree of safe fuzzy matching should be employed here to accept custom cluster domain names and IP addresses, as well as white space.
 
+`CheckCorefile(coreDNSVersion, corefile string) error`: returns true if the configuration is valid for the given version.  This is intended as a sanity checks to make sure a Corefile can be loaded by CoreDNS, e.g. by calling `setup()` for each plugin used.  This won't work for custom compilations CoreDNS - e.g. one compiled with external plugins are used.
+
+`Released(dockerImageID string) bool`: returns `true` if `dockerImageID` matches any _released_ image of CoreDNS.
+
+
 ## Command Line Converter
 
 We should also write a simple command line tool that allows someone to use these functions via the command line.
@@ -42,5 +47,6 @@ This is an example of how these tools could be used by an installer/upgrader...
 2. Check `Unsupported()`, if anything is unsupported, abort and warn user (allow user to override to pass this).
 3. Call `Migrate()`, if there is an error, abort and warn user.
 4. If there is no error, pause and ask user if they want to continue with the migration.  If the starting Corefile was at defaults, proceed use the migrated corefile.
+
 
 

--- a/kubernetes/migration/README.md
+++ b/kubernetes/migration/README.md
@@ -17,7 +17,7 @@ This Go library provides a set of functions to help handle migrations of CoreDNS
 
 `Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of plugins that are not recognized/supported by the migration tool (but may still be valid in CoreDNS).  We must handle all the default plugins, and we should make an effort to handle the most common non-default plugins. Each string returned is a warning, e.g. "plugin 'foo' is not supported by the migration tool." An empty list returned means there are no unsupported plugins/options present in the Corefile.
 
-Although it would be useful, we cannot for example provide a function `Default(coreDNSVersion, corefile string) boolean` that returns  `true` if the corefile is the default for a that version, because each management tool may deploy their own defaults.  So detection of default Corefiles must be implemented by each management tool that requires it.
+`Default(fromK8sVersion, corefile string) boolean`: returns `true` if the Corefile is the default for a that version of Kubernetes.  If `fromK8sVersion` is omitted, returns `true` if the Corefile is the default for any version.  Some degree of safe fuzzy matching should be employed here to accept custom cluster domain names and IP addresses, as well as white space.
 
 ## Command Line Converter
 
@@ -37,9 +37,10 @@ Usage:
 
 This is an example of how these tools could be used by an installer/upgrader... 
 
-1. check Deprecated(), if anything is deprecated, warn user, but continue install. 
-2. check Unsupported(), if anything is unsupported, abort and warn user (allow user to override to pass this).
-3. call Migrate(), if there is an error, abort and warn user.
-4. If there is no error, and the starting Corefile was not a default, pause and ask user if they want to continue with the migration.  If the starting Corefile was at defaults, proceed use the migrated corefile.
+0. Check `Default()`, if the Corefile is a default, simply re-deploy the new default over top the old one. No migration needed. If the Corefile is not a default, continue...
+1. Check `Deprecated()`, if anything is deprecated, warn user, but continue install. 
+2. Check `Unsupported()`, if anything is unsupported, abort and warn user (allow user to override to pass this).
+3. Call `Migrate()`, if there is an error, abort and warn user.
+4. If there is no error, pause and ask user if they want to continue with the migration.  If the starting Corefile was at defaults, proceed use the migrated corefile.
 
 

--- a/kubernetes/migration/README.md
+++ b/kubernetes/migration/README.md
@@ -21,7 +21,7 @@ This Go library provides a set of functions to help handle migrations of CoreDNS
 
 `CheckCorefile(coreDNSVersion, corefile string) bool`: returns true if the configuration is valid for the given version.  This is intended as a sanity checks to make sure a Corefile can be loaded by CoreDNS, e.g. by calling `setup()` for each plugin used.  This won't work for custom compilations CoreDNS - e.g. one compiled with external plugins are used.
 
-`Released(dockerImageID string) bool`: returns `true` if `dockerImageID` matches any _released_ image of CoreDNS.
+`Released(dockerImageID string) bool`: returns `true` if `dockerImageID` matches any _released_ image of CoreDNS. This includes all released verisons of CoreDNS, not just those associted with Kubernetes releases. 
 
 
 ## Command Line Converter

--- a/kubernetes/migration/README.md
+++ b/kubernetes/migration/README.md
@@ -4,9 +4,9 @@ This Go library provides a set of functions to help handle migrations of CoreDNS
 
 ## Proposed functions:
 
-`Deprecated(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of deprecated plugins or directives present in the Corefile.
+`Deprecated(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of deprecated plugins or directives present in the Corefile. Each string returned is a warning, e.g. "plugin 'foo' is deprecated." An empty list returned means there are no deprecated plugins/options present in the Corefile.
 
-`Removed(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of removed plugins or directives present in the Corefile.
+`Removed(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of removed plugins or directives present in the Corefile. Each string returned is a warning, e.g. "plugin 'foo' is no longer supported." An empty list returned means there are no removed plugins/options present in the Corefile.
 
 `Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefile string, deprecations boolean) (string, error)`: returns an automatically migrated version of the Corefile, or an error if it cannot. It should:
   * replace/convert any plugins/directives that have replacements (e.g. _proxy_ -> _forward_)
@@ -14,7 +14,7 @@ This Go library provides a set of functions to help handle migrations of CoreDNS
   * remove plugins/directives that do not have replacements (e.g. kubernetes `upstream`)
   * if _deprecations_ is set to true, also migrate deprecated plugins/directives.
 
-`Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of plugins that are not recognized/supported by the migration tool.  We must handle all the default plugins, and we should make an effort to handle the most common non-default plugins. 
+`Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of plugins that are not recognized/supported by the migration tool (but may still be valid in CoreDNS).  We must handle all the default plugins, and we should make an effort to handle the most common non-default plugins. Each string returned is a warning, e.g. "plugin 'foo' is not supported by the migration tool." An empty list returned means there are no unsupported plugins/options present in the Corefile.
 
 Although it would be useful, we cannot for example provide a function `Default(coreDNSVersion, corefile string) boolean` that returns  `true` if the corefile is the default for a that version, because each management tool may deploy their own defaults.  So detection of default Corefiles must be implemented by each management tool that requires it.
 

--- a/kubernetes/migration/spec.md
+++ b/kubernetes/migration/spec.md
@@ -4,19 +4,19 @@ This Go library provides a set of functions to help handle migrations of CoreDNS
 
 ## Proposed functions:
 
-`Deprecated(fromVersion, toVersion, corefile string) []string`: returns a list of deprecated plugins or directives present in the Corefile.
+`Deprecated(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of deprecated plugins or directives present in the Corefile.
 
-`Removed(fromVersion, toVersion, corefile string) []string`: returns a list of removed plugins or directives present in the Corefile.
+`Removed(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of removed plugins or directives present in the Corefile.
 
-`Migrate(fromVersion, toVersion, corefile string, deprecations boolean) (string, error)`: returns an automatically migrated version of the Corefile, or an error if it cannot. It should:
+`Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefile string, deprecations boolean) (string, error)`: returns an automatically migrated version of the Corefile, or an error if it cannot. It should:
   * replace/convert any plugins/directives that have replacements (e.g. _proxy_ -> _forward_)
   * return an error if replacable plugins/directives cannot be converted (e.g. proxy _options_ not available in _forward_)
   * remove plugins/directives that do not have replacements (e.g. kubernetes `upstream`)
   * if _deprecations_ is set to true, also migrate deprecated plugins/directives.
 
-`Unsupported(fromVersion, toVersion, corefile string) []string`: returns a list of plugins that are not recognized/supported by the migration tool.  We must handle all the default plugins, and we should make an effort to handle the most common non-default plugins. 
+`Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefile string) []string`: returns a list of plugins that are not recognized/supported by the migration tool.  We must handle all the default plugins, and we should make an effort to handle the most common non-default plugins. 
 
-Although it would be useful, we cannot for example provide a function `Default(version, corefile string) boolean` that returns  `true` if the corefile is the default for a that version, because each management tool may deploy their own defaults.  So detection of default Corefiles must be implemented by each management tool that requires it.
+Although it would be useful, we cannot for example provide a function `Default(coreDNSVersion, corefile string) boolean` that returns  `true` if the corefile is the default for a that version, because each management tool may deploy their own defaults.  So detection of default Corefiles must be implemented by each management tool that requires it.
 
 ## Command Line Converter
 
@@ -26,8 +26,8 @@ E.g.
 
 ```
 Usage:
-  corefile-tool deprecated --from <version> --to <version> --corefile <path>
-  corefile-tool removed --from <version> --to <version> --corefile <path> [--deprecations]
-  corefile-tool migrate --from <version> --to <version> --corefile <path>
+  corefile-tool deprecated --from <coredns-version> --to <coredns-version> --corefile <path>
+  corefile-tool removed --from <coredns-version> --to <coredns-version> --corefile <path> [--deprecations]
+  corefile-tool migrate --from <coredns-version> --to <coredns-version> --corefile <path>
   etc ...
 ```

--- a/kubernetes/migration/spec.md
+++ b/kubernetes/migration/spec.md
@@ -1,0 +1,33 @@
+# K8s/CoreDNS Corefile Migration Tools
+
+This Go library provides a set of functions to help handle migrations of CoreDNS Corefiles to be compatible with new versions of CoreDNS.  The task of upgrading CoreDNS is the responsibility of a variety of Kubernetes management tools (e.g. kubeadm and others), and the precise behavior may be different for each one.  This library abstracts some basic helper functions that make this easier to implement.
+
+## Proposed functions:
+
+`Deprecated(fromVersion, toVersion, corefile string) []string`: returns a list of deprecated plugins or directives present in the Corefile.
+
+`Removed(fromVersion, toVersion, corefile string) []string`: returns a list of removed plugins or directives present in the Corefile.
+
+`Migrate(fromVersion, toVersion, corefile string, deprecations boolean) (string, error)`: returns an automatically migrated version of the Corefile, or an error if it cannot. It should:
+  * replace/convert any plugins/directives that have replacements (e.g. _proxy_ -> _forward_)
+  * return an error if replacable plugins/directives cannot be converted (e.g. proxy _options_ not available in _forward_)
+  * remove plugins/directives that do not have replacements (e.g. kubernetes `upstream`)
+  * if _deprecations_ is set to true, also migrate deprecated plugins/directives.
+
+`Unsupported(fromVersion, toVersion, corefile string) []string`: returns a list of plugins that are not recognized/supported by the migration tool.  We must handle all the default plugins, and we should make an effort to handle the most common non-default plugins. 
+
+Although it would be useful, we cannot for example provide a function `Default(version, corefile string) boolean` that returns  `true` if the corefile is the default for a that version, because each management tool may deploy their own defaults.  So detection of default Corefiles must be implemented by each management tool that requires it.
+
+## Command Line Converter
+
+We should also write a simple command line tool that allows someone to use these functions via the command line.
+
+E.g.
+
+```
+Usage:
+  corefile-tool deprecated --from <version> --to <version> --corefile <path>
+  corefile-tool removed --from <version> --to <version> --corefile <path> [--deprecations]
+  corefile-tool migrate --from <version> --to <version> --corefile <path>
+  etc ...
+```


### PR DESCRIPTION
This is a draft spec for a migration tool/library that k8s mgmt tools can leverage to migrate CoreDNS Corefiles during upgrades.  Please review and let's discuss.  

Missing anything?
Too ambitious?
How far back should we go?  1.1.3?

