### PR TITLE
Add /tmp volume mount

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -112,6 +112,8 @@ spec:
         - name: config-volume
           mountPath: /etc/coredns
           readOnly: true
+        - name: tmp
+          mountPath: /tmp
         ports:
         - containerPort: 53
           name: dns
@@ -146,6 +148,8 @@ spec:
             scheme: HTTP
       dnsPolicy: Default
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config-volume
           configMap:
             name: coredns


### PR DESCRIPTION
For a workaround for related issues with crashing due to glog/klog issues, this add an EmptyDir volume and mounts it on /tmp

Fixes #137 