### PR TITLE
Add the noop (ignored) status

### DIFF
--- a/kubernetes/migration/notice.go
+++ b/kubernetes/migration/notice.go
@@ -22,7 +22,7 @@ func (n *Notice) ToString() string {
 	if n.Severity == unsupported {
 		s += "is unsupported by this migration tool in " + n.Version + "."
 	} else {
-		s += "was " + n.Severity + " in " + n.Version + "."
+		s += "is " + n.Severity + " in " + n.Version + "."
 	}
 	if n.ReplacedBy != "" {
 		s += fmt.Sprintf(` It is replaced by "%v".`, n.ReplacedBy)
@@ -34,7 +34,8 @@ func (n *Notice) ToString() string {
 }
 
 const (
-	deprecated  = "deprecated"  // plugin/option is deprecated
-	removed     = "removed"     // plugin/option has been removed
+	deprecated  = "deprecated"  // plugin/option is deprecated in CoreDNS
+	ignored     = "ignored"     // plugin/option is ignored by CoreDNS
+	removed     = "removed"     // plugin/option has been removed from CoreDNS
 	unsupported = "unsupported" // plugin/option is not supported by the migration tool
 )

--- a/kubernetes/migration/versions.go
+++ b/kubernetes/migration/versions.go
@@ -72,6 +72,10 @@ var Versions = map[string]release{
 					"labels":             {},
 					"pods":               {},
 					"endpoint_pod_names": {},
+					"upstream": {
+						status: ignored,
+						action: removeOption,
+					},
 					"ttl":                {},
 					"noendpoints":        {},
 					"transfer":           {},

--- a/kubernetes/migration/versions.go
+++ b/kubernetes/migration/versions.go
@@ -63,7 +63,7 @@ var Versions = map[string]release{
 						action: removeOption,
 					},
 					"endpoint": {
-						status: deprecated,
+						status: ignored,
 						action: removeExtraEndpoints,
 					},
 					"tls":                {},
@@ -124,7 +124,7 @@ var Versions = map[string]release{
 				options: map[string]option{
 					"resyncperiod": {},
 					"endpoint": {
-						status: deprecated,
+						status: ignored,
 						action: removeExtraEndpoints,
 					},
 					"tls":                {},


### PR DESCRIPTION
In CoreDNS we use 3 phases of deprecation,
1. deprecated - feature announced deprecated, but still fully functional
2. "noop" - feature is removed, but is it still tolerated in the corefile (coredns will still start)
3. removed - feature is removed, and no longer tolerated in the corefile (coredns will not start)

Calling this "noop" status "ignored".
This is mainly just book keeping, but for now an "ignored" feature is considered "removed" when migrating a config.