### PR TITLE
kubernetes: remove pipefail from setup.sh

### DIFF
--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -2,8 +2,6 @@
 
 # Deploys CoreDNS to a cluster currently running Kube-DNS.
 
-set -eo pipefail
-
 show_help () {
 cat << USAGE
 usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ]


### PR DESCRIPTION
Using pipefail causes the script to exit when `kubectl` commands cannot find a kubedns configmap.
Its perfectly normal (and more common) to not have a kubedns configmap.