### PR TITLE
Fill in remaining supported CoreDNS versions

### DIFF
--- a/kubernetes/migration/versions.go
+++ b/kubernetes/migration/versions.go
@@ -54,6 +54,11 @@ var Versions = map[string]release{
 					"consolidate": {},
 				},
 			},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
 			"health":   {},
 			"autopath": {},
 			"kubernetes": {
@@ -76,11 +81,11 @@ var Versions = map[string]release{
 						status: ignored,
 						action: removeOption,
 					},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
+					"ttl":         {},
+					"noendpoints": {},
+					"transfer":    {},
+					"fallthrough": {},
+					"ignore":      {},
 				},
 			},
 			"k8s_external": {
@@ -116,6 +121,11 @@ var Versions = map[string]release{
 			"errors": {
 				options: map[string]option{
 					"consolidate": {},
+				},
+			},
+			"log": {
+				options: map[string]option{
+					"class": {},
 				},
 			},
 			"health":   {},
@@ -195,6 +205,11 @@ var Versions = map[string]release{
 					"consolidate": {},
 				},
 			},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
 			"health":   {},
 			"autopath": {},
 			"kubernetes": {
@@ -222,6 +237,276 @@ var Versions = map[string]release{
 				options: map[string]option{
 					"apex": {},
 					"ttl":  {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"loop":        {},
+			"reload":      {},
+			"loadbalance": {},
+		},
+	},
+	"1.3.0": {
+		nextVersion:   "1.3.1",
+		dockerImageID: "2ee68ed074c6",
+		plugins: map[string]plugin{
+			"errors": {
+				options: map[string]option{
+					"consolidate": {},
+				},
+			},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"kubeconfig":         {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
+				},
+			},
+			"k8s_external": {
+				options: map[string]option{
+					"apex": {},
+					"ttl":  {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"loop":        {},
+			"reload":      {},
+			"loadbalance": {},
+		},
+	},
+	"1.2.6": {
+		nextVersion:   "1.3.0",
+		k8sRelease:    "1.13",
+		dockerImageID: "f59dcacceff4",
+		defaultConf: `.:53 {
+    errors
+    health
+    kubernetes * *** {
+        pods insecure
+        upstream
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    proxy . *
+    cache 30
+    loop
+    reload
+    loadbalance
+}`,
+		plugins: map[string]plugin{
+			"errors": {
+				options: map[string]option{
+					"consolidate": {},
+				},
+			},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"kubeconfig":         {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"loop":        {},
+			"reload":      {},
+			"loadbalance": {},
+		},
+	},
+	"1.2.5": {
+		nextVersion:   "1.2.6",
+		dockerImageID: "bd254cf72111",
+		plugins: map[string]plugin{
+			"errors": {},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"kubeconfig":         {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"loop":        {},
+			"reload":      {},
+			"loadbalance": {},
+		},
+	},
+	"1.2.4": {
+		nextVersion:   "1.2.5",
+		dockerImageID: "d35fe8670379",
+		plugins: map[string]plugin{
+			"errors": {},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"kubeconfig":         {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"loop":        {},
+			"reload":      {},
+			"loadbalance": {},
+		},
+	},
+	"1.2.2": {
+		nextVersion:   "1.2.4",
+		k8sRelease:    "1.12",
+		dockerImageID: "367cdc8433a4",
+		defaultConf: `.:53 {
+    errors
+    health
+    kubernetes * *** {
+        pods insecure
+        upstream
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    proxy . *
+    cache 30
+    loop
+    reload
+    loadbalance
+}`,
+		plugins: map[string]plugin{
+			"errors": {},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
 				},
 			},
 			"prometheus": {},

--- a/kubernetes/migration/versions.go
+++ b/kubernetes/migration/versions.go
@@ -715,46 +715,7 @@ var Versions = map[string]release{
     proxy . *
     cache 30
     reload
-}`,
-		plugins: map[string]plugin{
-			"errors": {},
-			"log": {
-				options: map[string]option{
-					"class": {},
-				},
-			},
-			"health":   {},
-			"autopath": {},
-			"kubernetes": {
-				options: map[string]option{
-					"resyncperiod":       {},
-					"endpoint":           {},
-					"tls":                {},
-					"namespaces":         {},
-					"labels":             {},
-					"pods":               {},
-					"endpoint_pod_names": {},
-					"upstream":           {},
-					"ttl":                {},
-					"noendpoints":        {},
-					"transfer":           {},
-					"fallthrough":        {},
-					"ignore":             {},
-				},
-			},
-			"prometheus": {},
-			"proxy":      {},
-			"forward":    {},
-			"cache": {
-				options: map[string]option{
-					"success":  {},
-					"denial":   {},
-					"prefetch": {},
-				},
-			},
-			"reload": {},
-		},
-	},
+}`},
 }
 
 var proxyToForwardOptionsMigrations = map[string]option{

--- a/kubernetes/migration/versions.go
+++ b/kubernetes/migration/versions.go
@@ -464,8 +464,53 @@ var Versions = map[string]release{
 			"loadbalance": {},
 		},
 	},
-	"1.2.2": {
+	"1.2.3": {
 		nextVersion:   "1.2.4",
+		dockerImageID: "d46263e07d7a",
+		plugins: map[string]plugin{
+			"errors": {},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"kubeconfig":         {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"loop":        {},
+			"reload":      {},
+			"loadbalance": {},
+		},
+	},
+	"1.2.2": {
+		nextVersion:   "1.2.3",
 		k8sRelease:    "1.12",
 		dockerImageID: "367cdc8433a4",
 		defaultConf: `.:53 {
@@ -522,6 +567,192 @@ var Versions = map[string]release{
 			"loop":        {},
 			"reload":      {},
 			"loadbalance": {},
+		},
+	},
+	"1.2.1": {
+		nextVersion:   "1.2.2",
+		dockerImageID: "a575d86d4058",
+		plugins: map[string]plugin{
+			"errors": {},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"loop":        {},
+			"reload":      {},
+			"loadbalance": {},
+		},
+	},
+	"1.2.0": {
+		nextVersion:   "1.2.1",
+		dockerImageID: "da1adafc0e78",
+		plugins: map[string]plugin{
+			"errors": {},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"reload":      {},
+			"loadbalance": {},
+		},
+	},
+	"1.1.4": {
+		nextVersion:   "1.2.0",
+		dockerImageID: "9919f8566026",
+		plugins: map[string]plugin{
+			"errors": {},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"reload":      {},
+			"loadbalance": {},
+		},
+	},
+	"1.1.3": {
+		nextVersion:   "1.1.4",
+		k8sRelease:    "1.11",
+		dockerImageID: "b3b94275d97c",
+		defaultConf: `.:53 {
+    errors
+    health
+    kubernetes * *** {
+        pods insecure
+        upstream
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    proxy . *
+    cache 30
+    reload
+}`,
+		plugins: map[string]plugin{
+			"errors": {},
+			"log": {
+				options: map[string]option{
+					"class": {},
+				},
+			},
+			"health":   {},
+			"autopath": {},
+			"kubernetes": {
+				options: map[string]option{
+					"resyncperiod":       {},
+					"endpoint":           {},
+					"tls":                {},
+					"namespaces":         {},
+					"labels":             {},
+					"pods":               {},
+					"endpoint_pod_names": {},
+					"upstream":           {},
+					"ttl":                {},
+					"noendpoints":        {},
+					"transfer":           {},
+					"fallthrough":        {},
+					"ignore":             {},
+				},
+			},
+			"prometheus": {},
+			"proxy":      {},
+			"forward":    {},
+			"cache": {
+				options: map[string]option{
+					"success":  {},
+					"denial":   {},
+					"prefetch": {},
+				},
+			},
+			"reload": {},
 		},
 	},
 }


### PR DESCRIPTION
- [x] Add versions of CoreDNS (up to 1.2.2) supported till k8s v1.12
- [x] Add versions of CoreDNS (up to 1.1.3) supported till k8s v1.11

Also, adds the `log` plugin to the list of supported plugins.
