### PR TITLE
debian: build all 3 ARCHs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Makefile for building packages for CoreDNS.
 
 # ARCH can be and default to amd64 is not set.
-# ARCH := amd64 armhf arm64
+ARCH := amd64 armhf arm64
 
 ifeq ($(ARCH),)
     ARCH:=amd64
@@ -10,7 +10,7 @@ endif
 .PHONY: debian
 debian:
 	for a in $(ARCH); do \
-	    dpkg-buildpackage -us -uc -b --target-arch $$aa ;\
+	    dpkg-buildpackage -us -uc -b --target-arch $$a ;\
 	done
 
 debian-clean:

--- a/debian/coredns.service
+++ b/debian/coredns.service
@@ -7,9 +7,9 @@ After=network.target
 PermissionsStartOnly=true
 LimitNOFILE=1048576
 LimitNPROC=512
-CapabilityBoundingSet=CAP_NET_BIND_SERVICE 
-AmbientCapabilities=CAP_NET_BIND_SERVICE 
-NoNewPrivileges=true 
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE
+AmbientCapabilities=CAP_NET_BIND_SERVICE
+NoNewPrivileges=true
 User=coredns
 WorkingDirectory=~
 ExecStart=/usr/bin/coredns -conf=/etc/coredns/Corefile


### PR DESCRIPTION
Just build them all, and some typos fixed.