### PR TITLE
debian: add corefile(5) as manual page

### DIFF
--- a/debian/coredns.manpages
+++ b/debian/coredns.manpages
@@ -1,2 +1,3 @@
 debian/man/coredns.1
+debian/man/corefile.5
 debian/man/coredns-*.7


### PR DESCRIPTION
This was missing from the deb.