### PR TITLE
kubernetes/migration: Add new default plugins/options

### DIFF
--- a/kubernetes/migration/migrate_test.go
+++ b/kubernetes/migration/migrate_test.go
@@ -15,6 +15,9 @@ func TestMigrate(t *testing.T) {
 	}{
 		{
 			name: "Remove invalid proxy option",
+			fromVersion:  "1.1.3",
+			toVersion:    "1.2.6",
+			deprecations: true,
 			startCorefile: `.:53 {
     errors
     health
@@ -34,11 +37,6 @@ func TestMigrate(t *testing.T) {
     loadbalance
 }
 `,
-
-			fromVersion:  "1.1.3",
-			toVersion:    "1.2.6",
-			deprecations: true,
-
 			expectedCorefile: `.:53 {
     errors
     health
@@ -59,6 +57,9 @@ func TestMigrate(t *testing.T) {
 		},
 		{
 			name: "Migrate from proxy to forward and handle Kubernetes deprecations",
+			fromVersion:  "1.3.1",
+			toVersion:    "1.5.0",
+			deprecations: true,
 			startCorefile: `.:53 {
     errors
     health
@@ -76,11 +77,6 @@ func TestMigrate(t *testing.T) {
     loadbalance
 }
 `,
-
-			fromVersion:  "1.3.1",
-			toVersion:    "1.5.0",
-			deprecations: true,
-
 			expectedCorefile: `.:53 {
     errors
     health
@@ -99,6 +95,44 @@ func TestMigrate(t *testing.T) {
 }
 `,
 		},
+		{
+			name: "add missing loop and ready plugins",
+			fromVersion:  "1.1.3",
+			toVersion:    "1.5.0",
+			deprecations: true,
+			startCorefile: `.:53 {
+    errors
+    health
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        upstream
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    proxy . /etc/resolv.conf
+    cache 30
+    reload
+    loadbalance
+}
+`,
+			expectedCorefile: `.:53 {
+    errors
+    health
+    kubernetes cluster.local in-addr.arpa ip6.arpa {
+        pods insecure
+        fallthrough in-addr.arpa ip6.arpa
+    }
+    prometheus :9153
+    forward . /etc/resolv.conf
+    cache 30
+    reload
+    loadbalance
+    loop
+    ready
+}
+`,
+		},
+
 	}
 
 	for _, testCase := range testCases {

--- a/kubernetes/migration/migrate_test.go
+++ b/kubernetes/migration/migrate_test.go
@@ -95,6 +95,7 @@ func TestMigrate(t *testing.T) {
     loop
     reload
     loadbalance
+    ready
 }
 `,
 		},

--- a/kubernetes/migration/notice.go
+++ b/kubernetes/migration/notice.go
@@ -38,4 +38,5 @@ const (
 	ignored     = "ignored"     // plugin/option is ignored by CoreDNS
 	removed     = "removed"     // plugin/option has been removed from CoreDNS
 	unsupported = "unsupported" // plugin/option is not supported by the migration tool
+	newdefault  = "newdefault"  // plugin/option was added to the default corefile
 )

--- a/kubernetes/migration/versions.go
+++ b/kubernetes/migration/versions.go
@@ -59,7 +59,11 @@ var Versions = map[string]release{
 					"class": {},
 				},
 			},
-			"health":   {},
+			"health": {},
+			"ready": {
+				status: newdefault,
+				action: func(*corefile.Plugin) (*corefile.Plugin, error) { return &corefile.Plugin{Name: "ready"}, nil },
+			},
 			"autopath": {},
 			"kubernetes": {
 				options: map[string]option{
@@ -808,7 +812,10 @@ var Versions = map[string]release{
 					"prefetch": {},
 				},
 			},
-			"loop":        {},
+			"loop": {
+				status: newdefault,
+				action: func(*corefile.Plugin) (*corefile.Plugin, error) { return &corefile.Plugin{Name: "loop"}, nil },
+			},
 			"reload":      {},
 			"loadbalance": {},
 		},

--- a/kubernetes/migration/versions.go
+++ b/kubernetes/migration/versions.go
@@ -6,6 +6,7 @@ import (
 
 type plugin struct {
 	status     string
+	add        serverActionFn
 	replacedBy string
 	additional string
 	action     pluginActionFn
@@ -14,6 +15,7 @@ type plugin struct {
 
 type option struct {
 	status     string
+	add        pluginActionFn
 	replacedBy string
 	additional string
 	action     optionActionFn
@@ -34,6 +36,7 @@ type release struct {
 	defaultConf string
 }
 
+type serverActionFn func(server *corefile.Server) (*corefile.Server, error)
 type pluginActionFn func(*corefile.Plugin) (*corefile.Plugin, error)
 type optionActionFn func(*corefile.Option) (*corefile.Option, error)
 
@@ -43,6 +46,36 @@ func removeOption(*corefile.Option) (*corefile.Option, error) { return nil, nil 
 func renamePlugin(p *corefile.Plugin, to string) (*corefile.Plugin, error) {
 	p.Name = to
 	return p, nil
+}
+
+func addToServerBlocksWithPlugins(sb *corefile.Server, newPlugin *corefile.Plugin, with []string) (*corefile.Server, error) {
+	if len(with) == 0 {
+		// add to all blocks
+		sb.Plugins = append(sb.Plugins, newPlugin)
+		return sb, nil
+	}
+	for _, p := range sb.Plugins {
+		for _, w := range with {
+			if w == p.Name {
+				// add to this block
+				sb.Plugins = append(sb.Plugins, newPlugin)
+				return sb, nil
+			}
+		}
+	}
+	return sb, nil
+}
+
+func addToKubernetesServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
+	return addToServerBlocksWithPlugins(sb, newPlugin, []string{"kubernetes"})
+}
+
+func addToForwardingServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
+	return addToServerBlocksWithPlugins(sb, newPlugin, []string{"forward", "proxy"})
+}
+
+func addToAllServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*corefile.Server, error) {
+	return addToServerBlocksWithPlugins(sb, newPlugin, []string{})
 }
 
 var Versions = map[string]release{
@@ -62,7 +95,9 @@ var Versions = map[string]release{
 			"health": {},
 			"ready": {
 				status: newdefault,
-				action: func(*corefile.Plugin) (*corefile.Plugin, error) { return &corefile.Plugin{Name: "ready"}, nil },
+				add: func(c *corefile.Server) (*corefile.Server, error) {
+					return addToKubernetesServerBlocks(c, &corefile.Plugin{Name: "ready"})
+				},
 			},
 			"autopath": {},
 			"kubernetes": {
@@ -814,7 +849,9 @@ var Versions = map[string]release{
 			},
 			"loop": {
 				status: newdefault,
-				action: func(*corefile.Plugin) (*corefile.Plugin, error) { return &corefile.Plugin{Name: "loop"}, nil },
+				add: func(s *corefile.Server) (*corefile.Server, error) {
+					return addToForwardingServerBlocks(s, &corefile.Plugin{Name: "loop"})
+				},
 			},
 			"reload":      {},
 			"loadbalance": {},


### PR DESCRIPTION
* New to the plugins/options migration structs:
   * Adds a new status "newdefault", which indicates when a plugins/option is added to the default configuration for the first time. 
   * Adds a new property `add`, which defines how to add the plugin to a server block, or option to its plugin.

* Migrate() now checks for all "newdefault" plugins/options and processes them per the `add` func.

* Defines handlers for `ready` and `loop` plugins.  Plugins placed relative to other plugins.  `ready` is placed in the server blocks containing `kubernetes` plugin.  `loop` is added to server blocks containing `forward` or `proxy`.  As of now in the default config this happens to be the same block.

This is critical for upgraders that always replace the Deployment with the newest version (e.g. kubeadm).  In 1.15, the `ready` plugin will be used, and hence the Deployment expects the `ready` plugin to be present in the corefile.  If it is not, the service will never report as ready.