### PR TITLE
k8s migration: use consistent term in README

### DIFF
--- a/kubernetes/migration/README.md
+++ b/kubernetes/migration/README.md
@@ -24,16 +24,16 @@ Plugin "baz" is unsupported by this migration tool in <version>.
 `Deprecated(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]Notice, error)`
 
 Deprecated returns a list of deprecation notices affecting the given Corefile.  Notices are returned for
-any deprecated, removed, or ignored plugins/directives present in the Corefile.  Notices are also returned for
+any deprecated, removed, or ignored plugins/options present in the Corefile.  Notices are also returned for
 any new default plugins that would be added in a migration.  Notices
 
 
 `Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string, deprecations bool) (string, error)`
 
 Migrate returns a migrated version of the Corefile, or an error if it cannot. It will:
-  * replace/convert any plugins/directives that have replacements (e.g. _proxy_ -> _forward_)
-  * return an error if replacable plugins/directives cannot be converted (e.g. proxy _options_ not available in _forward_)
-  * remove plugins/directives that do not have replacements (e.g. kubernetes `upstream`)
+  * replace/convert any plugins/options that have replacements (e.g. _proxy_ -> _forward_)
+  * return an error if replacable plugins/options cannot be converted (e.g. proxy _options_ not available in _forward_)
+  * remove plugins/options that do not have replacements (e.g. kubernetes `upstream`)
   * add in any new default plugins where applicable if they are not already present (e.g. adding _loop_ plugin when it was added).
     This will have to be case by case, and could potentially get complicated.
   * If deprecations is true, deprecated plugins/options will be migrated as soon as they are deprecated.


### PR DESCRIPTION
"directive" -> "option"