### PR TITLE
Add go.mod

### DIFF
--- a/kubernetes/migration/go.mod
+++ b/kubernetes/migration/go.mod
@@ -1,0 +1,3 @@
+module /Users/srajan/go/src/github.com/coredns/deployment/kubernetes/migration/
+
+go 1.12

--- a/kubernetes/migration/go.mod
+++ b/kubernetes/migration/go.mod
@@ -1,3 +1,3 @@
-module /Users/srajan/go/src/github.com/coredns/deployment/kubernetes/migration/
+module github.com/coredns/deployment/kubernetes/migration/
 
 go 1.12


### PR DESCRIPTION
Required to vendor the migration library in kubernetes/kubernetes.

Error message: 
```
go get github.com/coredns/deployment/kubernetes/migration@master: missing github.com/coredns/deployment/kubernetes/migration/go.mod at revision 517138abe415
```