### PR TITLE
kubernetes/migration: dont error out on no-op same-verison upgrades

### DIFF
--- a/kubernetes/migration/migrate.go
+++ b/kubernetes/migration/migrate.go
@@ -26,15 +26,18 @@ func Unsupported(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string) ([]No
 }
 
 func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string) ([]Notice, error) {
-	notices := []Notice{}
+	if fromCoreDNSVersion == toCoreDNSVersion {
+		return nil, nil
+	}
 	err := validateVersions(fromCoreDNSVersion, toCoreDNSVersion)
 	if err != nil {
-		return notices, err
+		return nil, err
 	}
 	cf, err := corefile.New(corefileStr)
 	if err != nil {
-		return notices, err
+		return nil, err
 	}
+	notices := []Notice{}
 	v := fromCoreDNSVersion
 	for {
 		v = Versions[v].nextVersion
@@ -126,6 +129,9 @@ func getStatus(fromCoreDNSVersion, toCoreDNSVersion, corefileStr, status string)
 // If deprecations is true, deprecated plugins/options will be migrated as soon as they are deprecated.
 // If deprecations is false, deprecated plugins/options will be migrated only once they become removed or ignored.
 func Migrate(fromCoreDNSVersion, toCoreDNSVersion, corefileStr string, deprecations bool) (string, error) {
+	if fromCoreDNSVersion == toCoreDNSVersion {
+		return corefileStr, nil
+	}
 	err := validateVersions(fromCoreDNSVersion, toCoreDNSVersion)
 	if err != nil {
 		return "", err

--- a/kubernetes/migration/migrate_test.go
+++ b/kubernetes/migration/migrate_test.go
@@ -187,9 +187,9 @@ mystub-2.example.org {
 `,
 		},
 		{
-			name:         "no-op same verison migration",
-			fromVersion:  "1.1.3",
-			toVersion:    "1.1.3",
+			name:         "no-op same version migration",
+			fromVersion:  "1.3.1",
+			toVersion:    "1.3.1",
 			deprecations: true,
 			startCorefile: `.:53 {
     errors
@@ -200,7 +200,7 @@ mystub-2.example.org {
         fallthrough in-addr.arpa ip6.arpa
     }
     prometheus :9153
-    proxy example.org 1.2.3.4:53
+    proxy . /etc/resolv.conf
     cache 30
     loop
     reload
@@ -216,7 +216,7 @@ mystub-2.example.org {
         fallthrough in-addr.arpa ip6.arpa
     }
     prometheus :9153
-    proxy example.org 1.2.3.4:53
+    proxy . /etc/resolv.conf
     cache 30
     loop
     reload
@@ -290,7 +290,7 @@ func TestDeprecated(t *testing.T) {
 	}
 	expected = []Notice{}
 	if len(result) != len(expected) {
-		t.Fatalf("expected to find %v notifications in noop upgrade; got %v", len(expected), len(result))
+		t.Fatalf("expected to find %v notifications in no-op upgrade; got %v", len(expected), len(result))
 	}
 }
 


### PR DESCRIPTION
When upgrading from and to the same version, don't error out anymore, just do a no-op.
E.g.  When Migrating from 1.3.1 to 1.3.1, just leave the corefile as is. When listing deprecation notices from 1.3.1 to 1.3.1, just return an empty list of deprecations instead of an error.