### PR TITLE
Support multiple k8s version for a release of coredns

### DIFF
--- a/kubernetes/migration/migrate.go
+++ b/kubernetes/migration/migrate.go
@@ -347,7 +347,7 @@ func Default(k8sVersion, corefileStr string) bool {
 	}
 NextVersion:
 	for _, v := range Versions {
-		for _, release := range v.k8sRelease {
+		for _, release := range v.k8sReleases {
 			if k8sVersion != "" && k8sVersion != release {
 				continue
 			}

--- a/kubernetes/migration/migrate.go
+++ b/kubernetes/migration/migrate.go
@@ -347,8 +347,10 @@ func Default(k8sVersion, corefileStr string) bool {
 	}
 NextVersion:
 	for _, v := range Versions {
-		if k8sVersion != "" && k8sVersion != v.k8sRelease {
-			continue
+		for _, release := range v.k8sRelease {
+			if k8sVersion != "" && k8sVersion != release {
+				continue
+			}
 		}
 		defCf, err := corefile.New(v.defaultConf)
 		if err != nil {

--- a/kubernetes/migration/versions.go
+++ b/kubernetes/migration/versions.go
@@ -25,7 +25,7 @@ type option struct {
 }
 
 type release struct {
-	k8sRelease     []string
+	k8sReleases    []string
 	nextVersion    string
 	priorVersion   string
 	dockerImageSHA string
@@ -37,7 +37,7 @@ type release struct {
 	//   server blocks, etc). e.g. Splitting plugins out into separate server blocks.
 	postProcess corefileAction
 
-	// defaultConf holds the default Corefile template packaged with the corresponding k8sRelease.
+	// defaultConf holds the default Corefile template packaged with the corresponding k8sReleases.
 	// Wildcards are used for fuzzy matching:
 	//   "*"   matches exactly one token
 	//   "***" matches 0 all remaining tokens on the line
@@ -262,7 +262,7 @@ var Versions = map[string]release{
 	"1.3.1": {
 		nextVersion:    "1.4.0",
 		priorVersion:   "1.3.0",
-		k8sRelease:     []string{"1.15", "1.14"},
+		k8sReleases:    []string{"1.15", "1.14"},
 		dockerImageSHA: "02382353821b12c21b062c59184e227e001079bb13ebd01f9d3270ba0fcbf1e4",
 		defaultConf: `.:53 {
     errors
@@ -438,7 +438,7 @@ var Versions = map[string]release{
 	"1.2.6": {
 		nextVersion:    "1.3.0",
 		priorVersion:   "1.2.5",
-		k8sRelease:     []string{"1.13"},
+		k8sReleases:    []string{"1.13"},
 		dockerImageSHA: "81936728011c0df9404cb70b95c17bbc8af922ec9a70d0561a5d01fefa6ffa51",
 		defaultConf: `.:53 {
     errors
@@ -730,7 +730,7 @@ var Versions = map[string]release{
 	"1.2.2": {
 		nextVersion:    "1.2.3",
 		priorVersion:   "1.2.1",
-		k8sRelease:     []string{"1.12"},
+		k8sReleases:    []string{"1.12"},
 		dockerImageSHA: "3e2be1cec87aca0b74b7668bbe8c02964a95a402e45ceb51b2252629d608d03a",
 		defaultConf: `.:53 {
     errors
@@ -1022,7 +1022,7 @@ var Versions = map[string]release{
 	},
 	"1.1.3": {
 		nextVersion:    "1.1.4",
-		k8sRelease:     []string{"1.11"},
+		k8sReleases:    []string{"1.11"},
 		dockerImageSHA: "a5dd18e048983c7401e15648b55c3ef950601a86dd22370ef5dfc3e72a108aaa",
 		defaultConf: `.:53 {
     errors

--- a/kubernetes/migration/versions.go
+++ b/kubernetes/migration/versions.go
@@ -25,7 +25,7 @@ type option struct {
 }
 
 type release struct {
-	k8sRelease     string
+	k8sRelease     []string
 	nextVersion    string
 	priorVersion   string
 	dockerImageSHA string
@@ -92,7 +92,6 @@ func addToAllServerBlocks(sb *corefile.Server, newPlugin *corefile.Plugin) (*cor
 var Versions = map[string]release{
 	"1.5.0": {
 		priorVersion:   "1.4.0",
-		k8sRelease:     "1.15",
 		dockerImageSHA: "e83beb5e43f8513fa735e77ffc5859640baea30a882a11cc75c4c3244a737d3c",
 		plugins: map[string]plugin{
 			"errors": {
@@ -263,7 +262,7 @@ var Versions = map[string]release{
 	"1.3.1": {
 		nextVersion:    "1.4.0",
 		priorVersion:   "1.3.0",
-		k8sRelease:     "1.14",
+		k8sRelease:     []string{"1.15", "1.14"},
 		dockerImageSHA: "02382353821b12c21b062c59184e227e001079bb13ebd01f9d3270ba0fcbf1e4",
 		defaultConf: `.:53 {
     errors
@@ -439,7 +438,7 @@ var Versions = map[string]release{
 	"1.2.6": {
 		nextVersion:    "1.3.0",
 		priorVersion:   "1.2.5",
-		k8sRelease:     "1.13",
+		k8sRelease:     []string{"1.13"},
 		dockerImageSHA: "81936728011c0df9404cb70b95c17bbc8af922ec9a70d0561a5d01fefa6ffa51",
 		defaultConf: `.:53 {
     errors
@@ -731,7 +730,7 @@ var Versions = map[string]release{
 	"1.2.2": {
 		nextVersion:    "1.2.3",
 		priorVersion:   "1.2.1",
-		k8sRelease:     "1.12",
+		k8sRelease:     []string{"1.12"},
 		dockerImageSHA: "3e2be1cec87aca0b74b7668bbe8c02964a95a402e45ceb51b2252629d608d03a",
 		defaultConf: `.:53 {
     errors
@@ -1023,7 +1022,7 @@ var Versions = map[string]release{
 	},
 	"1.1.3": {
 		nextVersion:    "1.1.4",
-		k8sRelease:     "1.11",
+		k8sRelease:     []string{"1.11"},
 		dockerImageSHA: "a5dd18e048983c7401e15648b55c3ef950601a86dd22370ef5dfc3e72a108aaa",
 		defaultConf: `.:53 {
     errors


### PR DESCRIPTION
This is applicable currently if k8s 1.15 continues to have CoreDNS 1.3.1