### PR TITLE
Add the ability to add specific configurations for the Kubernetes zone

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -57,7 +57,7 @@ data:
         health
         ready
         kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
-          pods insecure
+          KUBERNETES_CONFIG
           fallthrough in-addr.arpa ip6.arpa
         }FEDERATIONS
         prometheus :9153


### PR DESCRIPTION
Hi guys,

Thanks a lot for doing this.
In some cases of the migration we need to add some extra parameters when you have specific endpoints or when you do api server authentication (in which case you can specify a kueconfig file.
The rationale behind this change is to add the ability for people to specify a custom configuration for their Kubernetes plugin.

Example:
```bash
./deploy.sh -i 172.X.Y.Z -c "pods insecure\n          endpoint 'https://my-specific-endpoint.local':443\n          kubeconfig /var/lib/kubectl/kubeconfig service-account-context"
```

Thanks for your help,
Joseph