### PR TITLE
Fix bugs that failed to launch coredns service with Homebrew (macOS) 

### DIFF
--- a/HomebrewFormula/coredns.rb
+++ b/HomebrewFormula/coredns.rb
@@ -11,9 +11,7 @@ class Coredns < Formula
       hosts {
         fallthrough
       }
-      proxy . 8.8.8.8:53 8.8.4.4:53 {
-        protocol https_google
-      }
+      forward . https://8.8.8.8:53 https://8.8.4.4:53
       cache
       errors
     }
@@ -48,7 +46,7 @@ class Coredns < Formula
     <string>#{plist_name}</string>
     <key>ProgramArguments</key>
     <array>
-    <string>#{opt_sbin}/coredns</string>
+    <string>#{opt_bin}/coredns</string>
     <string>-conf</string>
     <string>#{etc}/coredns/Corefile</string>
     </array>
@@ -68,6 +66,6 @@ class Coredns < Formula
   end
 
   test do
-    assert_match "CoreDNS-#{version}", shell_output("#{sbin}/coredns -version")
+    assert_match "CoreDNS-#{version}", shell_output("#{bin}/coredns -version")
   end
 end


### PR DESCRIPTION
Hi, I'm shunirr.  Thank you for useful OSS.

I found 2 problems when uses with Homebrew (macOS). And I fixed it. Please check below.

#### 1. Can not launch `coredns` that mistook executable path in `homebrew.mxcl.coredns.plist`

I tried `brew services` command. But failed.

```
$ sudo brew services start coredns
Error: No such file or directory @ realpath_rec - /usr/local/Cellar/coredns/1.6.2/sbin/coredns
```

I found mistook path `sbin` in `homebrew.mxcl.coredns.plist`. I changed to replace to `bin`.

#### 2. Can not launch `coredns` that uses unknown directive `proxy` in default `Corefile`

I tried `coredns` command directory, because I want to check why failed to launch services.

And I saw below messages.

```
$ /usr/local/opt/coredns/bin/coredns --conf /usr/local/etc/coredns/Corefile
/usr/local/etc/coredns/Corefile:5 - Error during parsing: Unknown directive 'proxy'
```

And I refer to https://coredns.io/explugins/forward/ , And I replaced `proxy` to `forward`.

