### PR TITLE
debian: fix DEB_TARGET_ARCH maybe undefined

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+include /usr/share/dpkg/architecture.mk
+
 VERSION := $(shell curl -s https://api.github.com/repos/coredns/coredns/releases/latest  | jq -r '.tag_name[1:length]')
 # Github is ratelimiting this API pretty aggresively, error when not set.
 ifeq ($(VERSION),null)


### PR DESCRIPTION
FTBFS found on Ubuntu Eoan:
```
$ fakeroot debian/rules binary
dh_clean
dh binary --with systemd
   dh_update_autotools_config
   dh_autoreconf
   dh_auto_configure
   create-stamp debian/debhelper-build-stamp
   dh_testroot
   dh_prep
   debian/rules override_dh_auto_install
make[1]: Entering directory '/work/vicamo/coredns/deployment'
if [ ! -e coredns_1.6.4_linux_.tgz ]; then curl -L https://github.com/coredns/coredns/releases/download/v1.6.4/coredns_1.6.4_linux_.tgz -o coredns_1.6.4_linux_.tgz; fi
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     9    0     9    0     0     12      0 --:--:-- --:--:-- --:--:--    12
if [ ! -e v1.6.4.tar.gz ]; then  curl -L https://github.com/coredns/coredns/archive/v1.6.4.tar.gz -o v1.6.4.tar.gz; fi
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   123    0   123    0     0    173      0 --:--:-- --:--:-- --:--:--   173
100  487k    0  487k    0     0   213k      0 --:--:--  0:00:02 --:--:--  550k
mkdir -p debian/coredns/usr/bin debian/coredns/etc/coredns
mkdir -p debian/man v1.6.4
tar -xf coredns_1.6.4_linux_.tgz -C debian/coredns/usr/bin
tar: This does not look like a tar archive

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
make[1]: *** [debian/rules:39: override_dh_auto_install] Error 2
make[1]: Leaving directory '/work/vicamo/coredns/deployment'
make: *** [debian/rules:25: binary] Error 2
```

**DEB_TARGET_ARCH**, along with other multiarch variables, may not have been defined. To make sure they do, include `/usr/share/dpkg/architecture.mk` instead.

This won't affect the suggested build command in README.md, so it's still possible to specify foreign target arch by `--target-arch ARCH`.

Signed-off-by: You-Sheng Yang <vicamo@gmail.com>