### PR TITLE
fix typos on kubernetes deployment scripts

### DIFF
--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -6,10 +6,10 @@ show_help () {
 cat << USAGE
 usage: $0 [ -r REVERSE-CIDR ] [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ] [ -t YAML-TEMPLATE ]
 
-    -r : Define a reverse zone for the given CIDR. You may specifcy this option more
+    -r : Define a reverse zone for the given CIDR. You may specify this option more
          than once to add multiple reverse zones. If no reverse CIDRs are defined,
          then the default is to handle all reverse zones (i.e. in-addr.arpa and ip6.arpa)
-    -i : Specify the cluster DNS IP address. If not specificed, the IP address of
+    -i : Specify the cluster DNS IP address. If not specified, the IP address of
          the existing "kube-dns" service is used, if present.
     -s : Skips the translation of kube-dns configmap to the corresponding CoreDNS Corefile configuration.
 

--- a/kubernetes/rollback.sh
+++ b/kubernetes/rollback.sh
@@ -6,7 +6,7 @@ show_help () {
 cat << USAGE
 usage: $0  [ -i DNS-IP ] [ -d CLUSTER-DOMAIN ]
 
-    -i : Specify the cluster DNS IP address. If not specificed, the IP address of
+    -i : Specify the cluster DNS IP address. If not specified, the IP address of
          the existing "kube-dns" service is used, if present.
     -d : Specify the Cluster Domain. Default is "cluster.local"
 USAGE


### PR DESCRIPTION
Fixes typos on help texts(`-h`) on kubernetes `deploy` and `rollback` convenience scripts