### PR TITLE
Update CoreDNS version and update manifest

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -101,7 +101,7 @@ spec:
         beta.kubernetes.io/os: linux
       affinity:
         podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
+          requiredDuringSchedulingIgnoredDuringExecution:
           - weight: 100
             podAffinityTerm:
               labelSelector:
@@ -112,7 +112,7 @@ spec:
               topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: coredns/coredns:1.6.4
+        image: coredns/coredns:1.6.5
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -107,7 +107,7 @@ spec:
                 - key: k8s-app
                   operator: In
                   values: ["kube-dns"]
-                topologyKey: kubernetes.io/hostname
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
         image: coredns/coredns:1.6.4

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -102,12 +102,12 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-              labelSelector:
-                matchExpressions:
-                - key: k8s-app
-                  operator: In
-                  values: ["kube-dns"]
-              topologyKey: kubernetes.io/hostname
+          - labelSelector:
+              matchExpressions:
+              - key: k8s-app
+                operator: In
+                values: ["kube-dns"]
+            topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
         image: coredns/coredns:1.6.5

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -79,7 +79,7 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/name: "CoreDNS"
 spec:
-  replicas: 2
+  replicas: 1
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -102,8 +102,6 @@ spec:
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
               labelSelector:
                 matchExpressions:
                 - key: k8s-app

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -97,9 +97,20 @@ spec:
           operator: "Exists"
       nodeSelector:
         beta.kubernetes.io/os: linux
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values: ["kube-dns"]
+                topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: coredns/coredns:1.6.2
+        image: coredns/coredns:1.6.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -79,7 +79,9 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/name: "CoreDNS"
 spec:
-  replicas: 1
+  # replicas: not specified here:
+  # 1. Default is 1.
+  # 2. Will be tuned in real time if DNS horizontal auto-scaling is turned on.
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -54,7 +54,9 @@ data:
   Corefile: |
     .:53 {
         errors
-        health
+        health {
+          lameduck 12s
+        }
         ready
         kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
           pods insecure

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -55,7 +55,7 @@ data:
     .:53 {
         errors
         health {
-          lameduck 12s
+          lameduck 5s
         }
         ready
         kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {


### PR DESCRIPTION
Bumps CoreDNS version to 1.6.5 and adds pod anti-affinity to the deployment.
It also adds the `lameduck` option to the `health` plugin.

Fixes #197  
FIxes #199 

Signed-off-by: Sandeep Rajan <srajan@infoblox.com>
