### PR TITLE
Update coredns.yaml.sed to match k8s dns spec 1.1

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -59,7 +59,6 @@ data:
         }
         ready
         kubernetes CLUSTER_DOMAIN REVERSE_CIDRS {
-          pods insecure
           fallthrough in-addr.arpa ip6.arpa
         }FEDERATIONS
         prometheus :9153


### PR DESCRIPTION
The K8s Cluster DNS Spec 1.1 removed the requirement to support the deprecated pod ip dns names (e.g. `1-2-3-4.default.pod.cluster.local.`). kubernetes/dns#335