### PR TITLE
update service name of coredns

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -168,7 +168,7 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: kube-dns
+  name: coredns
   namespace: kube-system
   annotations:
     prometheus.io/port: "9153"

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -110,7 +110,7 @@ if [[ -z $REVERSE_CIDRS ]]; then
 fi
 if [[ -z $CLUSTER_DNS_IP ]]; then
   # Default IP to kube-dns IP
-  CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system kube-dns -o jsonpath="{.spec.clusterIP}")
+  CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system coredns -o jsonpath="{.spec.clusterIP}")
   if [ $? -ne 0 ]; then
       >&2 echo "Error! The IP address for DNS service couldn't be determined automatically. Please specify the DNS-IP with the '-i' option."
       exit 2

--- a/kubernetes/rollback.sh
+++ b/kubernetes/rollback.sh
@@ -36,7 +36,7 @@ done
 
 if [[ -z $CLUSTER_DNS_IP ]]; then
   # Default IP to kube-dns IP
-  CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system kube-dns -o jsonpath="{.spec.clusterIP}")
+  CLUSTER_DNS_IP=$(kubectl get service --namespace kube-system coredns -o jsonpath="{.spec.clusterIP}")
   if [ $? -ne 0 ]; then
       >&2 echo "Error! The IP address for DNS service couldn't be determined automatically. Please specify the DNS-IP with the '-i' option."
       exit 2


### PR DESCRIPTION
1.After I created the coredns through the yaml file, I found that the corresponding service could not be found, and I finally found that the names were inconsistent, which easily caused confusion.
2.Make Service's name consistent with ServiceAccount、ClusterRole、ConfigMap and Deployment of coredns.