### PR TITLE
Always use latest stable golang in CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,8 @@ initWorkingDir: &initWorkingDir
     GOROOT=$(go env GOROOT)
     sudo rm -r $(go env GOROOT)
     sudo mkdir $GOROOT
-    curl https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
+    LATEST=$(curl -s https://golang.org/VERSION?m=text)
+    curl https://dl.google.com/go/${LATEST}.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
 
 integrationDefaults: &integrationDefaults
   machine:


### PR DESCRIPTION
Same as we do in coredns/coredns circle-ci tests.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>