### PR TITLE
Use preferredDuringScheduling for Pod Anti Affinity

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -101,14 +101,16 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: k8s-app
-                operator: In
-                values: ["kube-dns"]
-            topologyKey: kubernetes.io/hostname
+         podAntiAffinity:
+           preferredDuringSchedulingIgnoredDuringExecution:
+           - weight: 100
+             podAffinityTerm:
+               labelSelector:
+                 matchExpressions:
+                   - key: k8s-app
+                     operator: In
+                     values: ["kube-dns"]
+               topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
         image: coredns/coredns:1.6.7


### PR DESCRIPTION
IIRC, the reason for "required" was because previously there were 2 replicas by default, and "preferred" would cause them both to be scheduled on the same node when building a cluster one node at a time.

But since now there is only one replica by default, we should use "preferred", to avoid the potential problem of under-scaling CoreDNS on a system where not enough nodes are available.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>