### PR TITLE
Add NET_RAW capability to make coredns compatible with cri-o

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -141,6 +141,7 @@ spec:
           capabilities:
             add:
             - NET_BIND_SERVICE
+            - NET_RAW
             drop:
             - all
           readOnlyRootFilesystem: true


### PR DESCRIPTION
Adding NET_RAW capability, not enabled by default on cri-o, makes it work even when hostNetwork: false

Otherwise, it will not be able to bind to cni interface on port 53, making it unusable in kube-dns service for internal and external dns resolution.