### PR TITLE
Update k8s deployment for 1.7.0

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -56,7 +56,9 @@ data:
           fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . UPSTREAMNAMESERVER
+        forward . UPSTREAMNAMESERVER {
+          max_concurrent 150
+        }
         cache 30
         loop
         reload
@@ -107,7 +109,7 @@ spec:
                topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: coredns/coredns:1.6.7
+        image: coredns/coredns:1.7.0
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -57,7 +57,7 @@ data:
         }
         prometheus :9153
         forward . UPSTREAMNAMESERVER {
-          max_concurrent 150
+          max_concurrent 1000
         }
         cache 30
         loop

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -43,7 +43,9 @@ function kube-dns-stubdomains-to-coredns {
       errors
       cache 30
       loop
-      forward . SD_DESTINATION
+      forward . SD_DESTINATION {
+        max_concurrent 1000
+      }
     }'
 
   function dequote {


### PR DESCRIPTION
Adds the new `max_concurrent` option to _forward_ to mitigate query spikes that might otherwise cause CoreDNS to OOM.  Setting this to 1000 should cap the memory footprint of concurrent upstream requests to within the ballpark of 2 MBs (thats 2MB in addition to the base CoreDNS footprint + cache). This is just a number I landed on after minimal waffling. My baseless reasoning: It's much higher than the kubedns limit (see below), and 2MB "is pretty small" such that it would keep OOMs in check during a query spike, while 1000 concurrent queries "should be large enough" that (considering that coredns would be scaled) it shouldn't be hitting the limit in normal circumstances.  I'm not married to this number.

We could probably safely set this much much lower. The roughly equivalent feature in kubedns is the `dns-forward-max` option in dnsmasq  which defaults to 150 (as deployed by kubedns).  The setting is not 100% apples to apples.  In CoreDNS, the limit only applies to queries forwarded upstream.  In kubedns, the limit applies to all queries, including in-cluster queries, and cached queries. However, cached and in-cluster are much cheaper (less latent) than queries forwarded upstream, so that difference is perhaps inconsequential.

Another difference in the limit feature is that dnsmasq drops packets beyond the limit (AFAIK), causing clients to timeout and retry, whereas CoreDNS replies with a SERVFAIL to the client.


Signed-off-by: Chris O'Haver <cohaver@infoblox.com>