### PR TITLE
remove endpointslices for now

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -15,7 +15,6 @@ rules:
   - ""
   resources:
   - endpoints
-  - endpointslice
   - services
   - pods
   - namespaces


### PR DESCRIPTION
The correct place to add this for testing is as a patch in the coredns/ci, for the purpose of testing until coredns is released with endpointslice support.  Once coredns is released with endpointslice support, it can be added here.

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>