### PR TITLE
Migrate helm chart from archived helm charts repo. 

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,29 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.1.0
+        with:
+          command: lint
+          config: ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.lint.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.1.0
+        with:
+          command: install
+          config: ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        run: |
+          curl -fsSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+          chmod 700 get_helm.sh
+          ./get_helm.sh
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add stable https://charts.helm.sh/stable
+          helm repo add incubator https://charts.helm.sh/incubator
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0
+        # with:
+        #   charts_dir: kubernetes/charts/coredns
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ To install:
 
 This installs the coredns binary in /usr/bin, adds a coredns user (homedir set to /var/lib/coredns)
 and a small Corefile /etc/coredns.
+
+# Kuebernetes
+
+## Helm Chart
+
+This repository provides helm chart repo. 
+
+```
+helm repo add coredns https://coredns.github.io/deployment/
+helm install coredns/coredns
+```

--- a/charts/coredns/.helmignore
+++ b/charts/coredns/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+OWNERS

--- a/charts/coredns/Chart.yaml
+++ b/charts/coredns/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: coredns
+version: 1.14.0
+appVersion: 1.8.0
+home: https://coredns.io
+icon: https://coredns.io/images/CoreDNS_Colour_Horizontal.png
+description: CoreDNS is a DNS server that chains plugins and provides Kubernetes DNS Services
+keywords:
+  - coredns
+  - dns
+  - kubedns
+sources:
+  - https://github.com/coredns/coredns
+maintainers:
+  - name: haad
+engine: gotpl
+type: application
+annotations:
+  artifacthub.io/changes: |
+    - Initial helm chart changelog

--- a/charts/coredns/README.md
+++ b/charts/coredns/README.md
@@ -1,0 +1,164 @@
+# CoreDNS
+
+[CoreDNS](https://coredns.io/) is a DNS server that chains plugins and provides DNS Services
+
+## DEPRECATION NOTICE
+
+This chart is deprecated and no longer supported.
+
+# TL;DR;
+
+```console
+$ helm install --name coredns --namespace=kube-system stable/coredns
+```
+
+## Introduction
+
+This chart bootstraps a [CoreDNS](https://github.com/coredns/coredns) deployment on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager. This chart will provide DNS Services and can be deployed in multiple configuration to support various scenarios listed below:
+
+ - CoreDNS as a cluster dns service and a drop-in replacement for Kube/SkyDNS. This is the default mode and CoreDNS is deployed as cluster-service in kube-system namespace. This mode is chosen by setting `isClusterService` to true.
+ - CoreDNS as an external dns service. In this mode CoreDNS is deployed as any kubernetes app in user specified namespace. The CoreDNS service can be exposed outside the cluster by using using either the NodePort or LoadBalancer type of service. This mode is chosen by setting `isClusterService` to false.
+ - CoreDNS as an external dns provider for kubernetes federation. This is a sub case of 'external dns service' which uses etcd plugin for CoreDNS backend. This deployment mode as a dependency on `etcd-operator` chart, which needs to be pre-installed.
+
+## Prerequisites
+
+-	Kubernetes 1.10 or later
+
+## Installing the Chart
+
+The chart can be installed as follows:
+
+```console
+$ helm install --name coredns --namespace=kube-system stable/coredns
+```
+
+The command deploys CoreDNS on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists various ways to override default configuration during deployment.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `my-release` deployment:
+
+```console
+$ helm delete coredns
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+| Parameter                               | Description                                                                           | Default                                                     |
+|:----------------------------------------|:--------------------------------------------------------------------------------------|:------------------------------------------------------------|
+| `image.repository`                      | The image repository to pull from                                                     | coredns/coredns                                             |
+| `image.tag`                             | The image tag to pull from                                                            | `v1.7.1`                                                    |
+| `image.pullPolicy`                      | Image pull policy                                                                     | IfNotPresent                                                |
+| `replicaCount`                          | Number of replicas                                                                    | 1                                                           |
+| `resources.limits.cpu`                  | Container maximum CPU                                                                 | `100m`                                                      |
+| `resources.limits.memory`               | Container maximum memory                                                              | `128Mi`                                                     |
+| `resources.requests.cpu`                | Container requested CPU                                                               | `100m`                                                      |
+| `resources.requests.memory`             | Container requested memory                                                            | `128Mi`                                                     |
+| `serviceType`                           | Kubernetes Service type                                                               | `ClusterIP`                                                 |
+| `prometheus.service.enabled`            | Set this to `true` to create Service for Prometheus metrics                           | `false`                                                     |
+| `prometheus.service.annotations`        | Annotations to add to the metrics Service                                             | `{prometheus.io/scrape: "true", prometheus.io/port: "9153"}`|
+| `prometheus.monitor.enabled`            | Set this to `true` to create ServiceMonitor for Prometheus operator                   | `false`                                                     |
+| `prometheus.monitor.additionalLabels`   | Additional labels that can be used so ServiceMonitor will be discovered by Prometheus | {}                                                          |
+| `prometheus.monitor.namespace`          | Selector to select which namespaces the Endpoints objects are discovered from.        | `""`                                                        |
+| `service.clusterIP`                     | IP address to assign to service                                                       | `""`                                                        |
+| `service.loadBalancerIP`                | IP address to assign to load balancer (if supported)                                  | `""`                                                        |
+| `service.externalIPs`                   | External IP addresses                                                                 | []                                                          |
+| `service.externalTrafficPolicy`         | Enable client source IP preservation                                                  | []                                                          |
+| `service.annotations`                   | Annotations to add to service                                                         | {}                                                          |
+| `serviceAccount.create`                 | If true, create & use serviceAccount                                                  | false                                                       |
+| `serviceAccount.name`                   | If not set & create is true, use template fullname                                    |                                                             |
+| `rbac.create`                           | If true, create & use RBAC resources                                                  | true                                                        |
+| `rbac.pspEnable`                        | Specifies whether a PodSecurityPolicy should be created.                              | `false`                                                     |
+| `isClusterService`                      | Specifies whether chart should be deployed as cluster-service or normal k8s app.      | true                                                        |
+| `priorityClassName`                     | Name of Priority Class to assign pods                                                 | `""`                                                        |
+| `servers`                               | Configuration for CoreDNS and plugins                                                 | See values.yml                                              |
+| `affinity`                              | Affinity settings for pod assignment                                                  | {}                                                          |
+| `nodeSelector`                          | Node labels for pod assignment                                                        | {}                                                          |
+| `tolerations`                           | Tolerations for pod assignment                                                        | []                                                          |
+| `zoneFiles`                             | Configure custom Zone files                                                           | []                                                          |
+| `extraVolumes`                          | Optional array of volumes to create                                                   | []                                                          |
+| `extraVolumeMounts`                     | Optional array of volumes to mount inside the CoreDNS container                       | []                                                          |
+| `extraSecrets`                          | Optional array of secrets to mount inside the CoreDNS container                       | []                                                          |
+| `customLabels`                          | Optional labels for Deployment(s), Pod, Service, ServiceMonitor objects               | {}                                                          |
+| `rollingUpdate.maxUnavailable`          | Maximum number of unavailable replicas during rolling update                          | `1`                                                         |
+| `rollingUpdate.maxSurge`                | Maximum number of pods created above desired number of pods                           | `25%`                                                       |
+| `podDisruptionBudget`                   | Optional PodDisruptionBudget                                                          | {}                                                          |
+| `podAnnotations`                        | Optional Pod only Annotations                                                         | {}                                                          |
+| `terminationGracePeriodSeconds`         | Optional duration in seconds the pod needs to terminate gracefully.                   | 30                                                          |
+| `preStopSleep`                          | Definition of Kubernetes preStop hook executed before Pod termination                 | {}                                                          |
+| `hpa.enabled`                           | Enable Hpa autoscaler instead of proportional one                                     | `false`                                                     |
+| `hpa.minReplicas`                       | Hpa minimum number of CoreDNS replicas                                                | `1`                                                         |
+| `hpa.maxReplicas`                       | Hpa maximum number of CoreDNS replicas                                                | `2`                                                         |
+| `hpa.metrics`                           | Metrics definitions used by Hpa to scale up and down                                  | {}                                                          |
+| `autoscaler.enabled`                    | Optionally enabled a cluster-proportional-autoscaler for CoreDNS                      | `false`                                                     |
+| `autoscaler.coresPerReplica`            | Number of cores in the cluster per CoreDNS replica                                    | `256`                                                       |
+| `autoscaler.nodesPerReplica`            | Number of nodes in the cluster per CoreDNS replica                                    | `16`                                                        |
+| `autoscaler.min`                        | Min size of replicaCount                                                              | 0                                                           |
+| `autoscaler.max`                        | Max size of replicaCount                                                              | 0  (aka no max)                                             |
+| `autoscaler.includeUnschedulableNodes`  | Should the replicas scale based on the total number or only schedulable nodes         | `false`                                                     |
+| `autoscaler.preventSinglePointFailure`  | If true does not allow single points of failure to form                               | `true`                                                      |
+| `autoscaler.image.repository`           | The image repository to pull autoscaler from                                          | k8s.gcr.io/cluster-proportional-autoscaler-amd64            |
+| `autoscaler.image.tag`                  | The image tag to pull autoscaler from                                                 | `1.7.1`                                                     |
+| `autoscaler.image.pullPolicy`           | Image pull policy for the autoscaler                                                  | IfNotPresent                                                |
+| `autoscaler.priorityClassName`          | Optional priority class for the autoscaler pod. `priorityClassName` used if not set.  | `""`                                                        |
+| `autoscaler.affinity`                   | Affinity settings for pod assignment for autoscaler                                   | {}                                                          |
+| `autoscaler.nodeSelector`               | Node labels for pod assignment for autoscaler                                         | {}                                                          |
+| `autoscaler.tolerations`                | Tolerations for pod assignment for autoscaler                                         | []                                                          |
+| `autoscaler.resources.limits.cpu`       | Container maximum CPU for cluster-proportional-autoscaler                             | `20m`                                                       |
+| `autoscaler.resources.limits.memory`    | Container maximum memory for cluster-proportional-autoscaler                          | `10Mi`                                                      |
+| `autoscaler.resources.requests.cpu`     | Container requested CPU for cluster-proportional-autoscaler                           | `20m`                                                       |
+| `autoscaler.resources.requests.memory`  | Container requested memory for cluster-proportional-autoscaler                        | `10Mi`                                                      |
+| `autoscaler.configmap.annotations`      | Annotations to add to autoscaler config map. For example to stop CI renaming them     | {}                                                          |
+
+See `values.yaml` for configuration notes. Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install --name coredns \
+  --set rbac.create=false \
+    stable/coredns
+```
+
+The above command disables automatic creation of RBAC rules.
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the chart. For example,
+
+```console
+$ helm install --name coredns -f values.yaml stable/coredns
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+
+## Caveats
+
+The chart will automatically determine which protocols to listen on based on
+the protocols you define in your zones. This means that you could potentially
+use both "TCP" and "UDP" on a single port.
+Some cloud environments like "GCE" or "Azure container service" cannot
+create external loadbalancers with both "TCP" and "UDP" protocols. So
+When deploying CoreDNS with `serviceType="LoadBalancer"` on such cloud
+environments, make sure you do not attempt to use both protocols at the same
+time.
+
+## Autoscaling
+
+By setting `autoscaler.enabled = true` a
+[cluster-proportional-autoscaler](https://github.com/kubernetes-incubator/cluster-proportional-autoscaler)
+will be deployed. This will default to a coredns replica for every 256 cores, or
+16 nodes in the cluster. These can be changed with `autoscaler.coresPerReplica`
+and `autoscaler.nodesPerReplica`. When cluster is using large nodes (with more
+cores), `coresPerReplica` should dominate. If using small nodes,
+`nodesPerReplica` should dominate.
+
+This also creates a ServiceAccount, ClusterRole, and ClusterRoleBinding for
+the autoscaler deployment.
+
+`replicaCount` is ignored if this is enabled.
+
+By setting `hpa.enabled = true` a [Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
+is enabled for Coredns deployment. This can scale number of replicas based on meitrics
+like CpuUtilization, MemoryUtilization or Custom ones.

--- a/charts/coredns/templates/NOTES.txt
+++ b/charts/coredns/templates/NOTES.txt
@@ -1,0 +1,30 @@
+{{- if .Values.isClusterService }}
+CoreDNS is now running in the cluster as a cluster-service.
+{{- else }}
+CoreDNS is now running in the cluster.
+It can be accessed using the below endpoint
+{{- if contains "NodePort" .Values.serviceType }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ template "coredns.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "$NODE_IP:$NODE_PORT"
+{{- else if contains "LoadBalancer" .Values.serviceType }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+        You can watch the status by running 'kubectl get svc -w {{ template "coredns.fullname" . }}'
+
+    export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ template "coredns.fullname" . }} -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+    echo $SERVICE_IP
+{{- else if contains "ClusterIP"  .Values.serviceType }}
+    "{{ template "coredns.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+    from within the cluster
+{{- end }}
+{{- end }}
+
+It can be tested with the following:
+
+1. Launch a Pod with DNS tools:
+
+kubectl run -it --rm --restart=Never --image=infoblox/dnstools:latest dnstools
+
+2. Query the DNS server:
+
+/ # host kubernetes

--- a/charts/coredns/templates/_helpers.tpl
+++ b/charts/coredns/templates/_helpers.tpl
@@ -1,0 +1,149 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "coredns.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "coredns.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Generate the list of ports automatically from the server definitions
+*/}}
+{{- define "coredns.servicePorts" -}}
+    {{/* Set ports to be an empty dict */}}
+    {{- $ports := dict -}}
+    {{/* Iterate through each of the server blocks */}}
+    {{- range .Values.servers -}}
+        {{/* Capture port to avoid scoping awkwardness */}}
+        {{- $port := toString .port -}}
+
+        {{/* If none of the server blocks has mentioned this port yet take note of it */}}
+        {{- if not (hasKey $ports $port) -}}
+            {{- $ports := set $ports $port (dict "istcp" false "isudp" false) -}}
+        {{- end -}}
+        {{/* Retrieve the inner dict that holds the protocols for a given port */}}
+        {{- $innerdict := index $ports $port -}}
+
+        {{/*
+        Look at each of the zones and check which protocol they serve
+        At the moment the following are supported by CoreDNS:
+        UDP: dns://
+        TCP: tls://, grpc://
+        */}}
+        {{- range .zones -}}
+            {{- if has (default "" .scheme) (list "dns://") -}}
+                {{/* Optionally enable tcp for this service as well */}}
+                {{- if eq (default false .use_tcp) true }}
+                    {{- $innerdict := set $innerdict "istcp" true -}}
+                {{- end }}
+                {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- end -}}
+
+            {{- if has (default "" .scheme) (list "tls://" "grpc://") -}}
+                {{- $innerdict := set $innerdict "istcp" true -}}
+            {{- end -}}
+        {{- end -}}
+
+        {{/* If none of the zones specify scheme, default to dns:// on both tcp & udp */}}
+        {{- if and (not (index $innerdict "istcp")) (not (index $innerdict "isudp")) -}}
+            {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- $innerdict := set $innerdict "istcp" true -}}
+        {{- end -}}
+
+        {{/* Write the dict back into the outer dict */}}
+        {{- $ports := set $ports $port $innerdict -}}
+    {{- end -}}
+
+    {{/* Write out the ports according to the info collected above */}}
+    {{- range $port, $innerdict := $ports -}}
+        {{- if index $innerdict "isudp" -}}
+            {{- printf "- {port: %v, protocol: UDP, name: udp-%s}\n" $port $port -}}
+        {{- end -}}
+        {{- if index $innerdict "istcp" -}}
+            {{- printf "- {port: %v, protocol: TCP, name: tcp-%s}\n" $port $port -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Generate the list of ports automatically from the server definitions
+*/}}
+{{- define "coredns.containerPorts" -}}
+    {{/* Set ports to be an empty dict */}}
+    {{- $ports := dict -}}
+    {{/* Iterate through each of the server blocks */}}
+    {{- range .Values.servers -}}
+        {{/* Capture port to avoid scoping awkwardness */}}
+        {{- $port := toString .port -}}
+
+        {{/* If none of the server blocks has mentioned this port yet take note of it */}}
+        {{- if not (hasKey $ports $port) -}}
+            {{- $ports := set $ports $port (dict "istcp" false "isudp" false) -}}
+        {{- end -}}
+        {{/* Retrieve the inner dict that holds the protocols for a given port */}}
+        {{- $innerdict := index $ports $port -}}
+
+        {{/*
+        Look at each of the zones and check which protocol they serve
+        At the moment the following are supported by CoreDNS:
+        UDP: dns://
+        TCP: tls://, grpc://
+        */}}
+        {{- range .zones -}}
+            {{- if has (default "" .scheme) (list "dns://") -}}
+                {{/* Optionally enable tcp for this service as well */}}
+                {{- if eq (default false .use_tcp) true }}
+                    {{- $innerdict := set $innerdict "istcp" true -}}
+                {{- end }}
+                {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- end -}}
+
+            {{- if has (default "" .scheme) (list "tls://" "grpc://") -}}
+                {{- $innerdict := set $innerdict "istcp" true -}}
+            {{- end -}}
+        {{- end -}}
+
+        {{/* If none of the zones specify scheme, default to dns:// on both tcp & udp */}}
+        {{- if and (not (index $innerdict "istcp")) (not (index $innerdict "isudp")) -}}
+            {{- $innerdict := set $innerdict "isudp" true -}}
+            {{- $innerdict := set $innerdict "istcp" true -}}
+        {{- end -}}
+
+        {{/* Write the dict back into the outer dict */}}
+        {{- $ports := set $ports $port $innerdict -}}
+    {{- end -}}
+
+    {{/* Write out the ports according to the info collected above */}}
+    {{- range $port, $innerdict := $ports -}}
+        {{- if index $innerdict "isudp" -}}
+            {{- printf "- {containerPort: %v, protocol: UDP, name: udp-%s}\n" $port $port -}}
+        {{- end -}}
+        {{- if index $innerdict "istcp" -}}
+            {{- printf "- {containerPort: %v, protocol: TCP, name: tcp-%s}\n" $port $port -}}
+        {{- end -}}
+    {{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "coredns.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "coredns.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/coredns/templates/clusterrole-autoscaler.yaml
+++ b/charts/coredns/templates/clusterrole-autoscaler.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.autoscaler.enabled .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["list","watch"]
+  - apiGroups: [""]
+    resources: ["replicationcontrollers/scale"]
+    verbs: ["get", "update"]
+  - apiGroups: ["extensions", "apps"]
+    resources: ["deployments/scale", "replicasets/scale"]
+    verbs: ["get", "update"]
+# Remove the configmaps rule once below issue is fixed:
+# kubernetes-incubator/cluster-proportional-autoscaler#16
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create"]
+{{- end }}

--- a/charts/coredns/templates/clusterrole.yaml
+++ b/charts/coredns/templates/clusterrole.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - endpoints
+  - services
+  - pods
+  - namespaces
+  verbs:
+  - list
+  - watch
+{{- if .Values.rbac.pspEnable }}
+- apiGroups:
+  - policy
+  - extensions
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - use
+  resourceNames:
+  - {{ template "coredns.fullname" . }}
+{{- end }}
+{{- end }}

--- a/charts/coredns/templates/clusterrolebinding-autoscaler.yaml
+++ b/charts/coredns/templates/clusterrolebinding-autoscaler.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.autoscaler.enabled .Values.rbac.create }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "coredns.fullname" . }}-autoscaler
+subjects:
+- kind: ServiceAccount
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/coredns/templates/clusterrolebinding.yaml
+++ b/charts/coredns/templates/clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "coredns.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "coredns.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/coredns/templates/configmap-autoscaler.yaml
+++ b/charts/coredns/templates/configmap-autoscaler.yaml
@@ -1,0 +1,37 @@
+{{- if .Values.autoscaler.enabled }}
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  namespace:  {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+    {{- if .Values.customLabels }}
+    {{- toYaml .Values.customLabels | nindent 4 }}
+    {{- end }}
+  {{- if .Values.autoscaler.configmap.annotations }}
+  annotations:
+    {{- toYaml .Values.autoscaler.configmap.annotations | nindent 4 }}
+  {{- end }}
+data:
+  # When cluster is using large nodes(with more cores), "coresPerReplica" should dominate.
+  # If using small nodes, "nodesPerReplica" should dominate.
+  linear: |-
+    {
+      "coresPerReplica": {{ .Values.autoscaler.coresPerReplica | float64 }},
+      "nodesPerReplica": {{ .Values.autoscaler.nodesPerReplica | float64 }},
+      "preventSinglePointFailure": {{ .Values.autoscaler.preventSinglePointFailure }},
+      "min": {{ .Values.autoscaler.min | int }},
+      "max": {{ .Values.autoscaler.max | int }},
+      "includeUnschedulableNodes": {{ .Values.autoscaler.includeUnschedulableNodes }}
+    }
+{{- end }}

--- a/charts/coredns/templates/configmap.yaml
+++ b/charts/coredns/templates/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+data:
+  Corefile: |-
+    {{ range .Values.servers }}
+    {{- range $idx, $zone := .zones }}{{ if $idx }} {{ else }}{{ end }}{{ default "" $zone.scheme }}{{ default "." $zone.zone }}{{ else }}.{{ end -}}
+    {{- if .port }}:{{ .port }} {{ end -}}
+    {
+      {{- range .plugins }}
+        {{ .name }}{{ if .parameters }} {{ .parameters }}{{ end }}{{ if .configBlock }} {
+{{ .configBlock | indent 12 }}
+        }{{ end }}
+      {{- end }}
+    }
+    {{ end }}
+  {{- range .Values.zoneFiles }}
+  {{ .filename }}: {{ toYaml .contents | indent 4 }}
+  {{- end }}

--- a/charts/coredns/templates/deployment-autoscaler.yaml
+++ b/charts/coredns/templates/deployment-autoscaler.yaml
@@ -1,0 +1,77 @@
+{{- if and (.Values.autoscaler.enabled) (not .Values.hpa.enabled) }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      {{- if .Values.isClusterService }}
+      k8s-app: {{ .Chart.Name }}-autoscaler
+      {{- end }}
+      app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+  template:
+    metadata:
+      labels:
+        {{- if .Values.isClusterService }}
+        k8s-app: {{ .Chart.Name }}-autoscaler
+        {{- end }}
+        app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        {{- if .Values.customLabels }}
+        {{ toYaml .Values.customLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap-autoscaler.yaml") . | sha256sum }}
+        {{- if .Values.isClusterService }}
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "coredns.fullname" . }}-autoscaler
+      {{- $priorityClassName := default .Values.priorityClassName .Values.autoscaler.priorityClassName }}
+      {{- if $priorityClassName }}
+      priorityClassName: {{ $priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.autoscaler.affinity }}
+      affinity:
+{{ toYaml .Values.autoscaler.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.autoscaler.tolerations }}
+      tolerations:
+{{ toYaml .Values.autoscaler.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.autoscaler.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.autoscaler.nodeSelector | indent 8 }}
+      {{- end }}
+      containers:
+      - name: autoscaler
+        image: "{{ .Values.autoscaler.image.repository }}:{{ .Values.autoscaler.image.tag }}"
+        imagePullPolicy: {{ .Values.autoscaler.image.pullPolicy }}
+        resources:
+{{ toYaml .Values.autoscaler.resources | indent 10 }}
+        command:
+          - /cluster-proportional-autoscaler
+          - --namespace={{ .Release.Namespace }}
+          - --configmap={{ template "coredns.fullname" . }}-autoscaler
+          - --target=Deployment/{{ template "coredns.fullname" . }}
+          - --logtostderr=true
+          - --v=2
+{{- end }}

--- a/charts/coredns/templates/deployment.yaml
+++ b/charts/coredns/templates/deployment.yaml
@@ -1,0 +1,140 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+spec:
+  {{- if not .Values.autoscaler.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: {{ .Values.rollingUpdate.maxUnavailable }}
+      maxSurge: {{ .Values.rollingUpdate.maxSurge }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      {{- if .Values.isClusterService }}
+      k8s-app: {{ .Chart.Name | quote }}
+      {{- end }}
+      app.kubernetes.io/name: {{ template "coredns.name" . }}
+  template:
+    metadata:
+      labels:
+        {{- if .Values.isClusterService }}
+        k8s-app: {{ .Chart.Name | quote }}
+        {{- end }}
+        app.kubernetes.io/name: {{ template "coredns.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        {{- if .Values.customLabels }}
+        {{ toYaml .Values.customLabels }}
+        {{- end }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- if .Values.isClusterService }}
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: '[{"key":"CriticalAddonsOnly", "operator":"Exists"}]'
+        {{- end }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+    spec:
+      {{- if .Values.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
+      serviceAccountName: {{ template "coredns.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.isClusterService }}
+      dnsPolicy: Default
+      {{- end }}
+      {{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      containers:
+      - name: "coredns"
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: [ "-conf", "/etc/coredns/Corefile" ]
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/coredns
+{{- range .Values.extraSecrets }}
+        - name: {{ .name }}
+          mountPath: {{ .mountPath }}
+          readOnly: true
+{{- end }}
+{{- if .Values.extraVolumeMounts }}
+{{- toYaml .Values.extraVolumeMounts | nindent 8}}
+{{- end }}
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+        ports:
+{{ include "coredns.containerPorts" . | indent 8 }}
+        livenessProbe:
+          httpGet:
+            path: /health
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 60
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 8181
+            scheme: HTTP
+          initialDelaySeconds: 10
+          timeoutSeconds: 5
+          successThreshold: 1
+          failureThreshold: 5
+        {{- if .Values.preStopSleep }}
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/usr/bin/sleep", "{{ .Values.preStopSleep }}"]
+        {{- end }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ template "coredns.fullname" . }}
+            items:
+            - key: Corefile
+              path: Corefile
+            {{ range .Values.zoneFiles }}
+            - key: {{ .filename }}
+              path: {{ .filename }}
+            {{ end }}
+{{- range .Values.extraSecrets }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .name }}
+            defaultMode: 400
+{{- end }}
+{{- if .Values.extraVolumes }}
+{{ toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}

--- a/charts/coredns/templates/hpa.yaml
+++ b/charts/coredns/templates/hpa.yaml
@@ -1,0 +1,29 @@
+{{- if and (.Values.hpa.enabled) (not .Values.autoscaler.enabled) }}
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "coredns.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+{{ toYaml .Values.hpa.metrics | indent 4 }}
+{{- end }}

--- a/charts/coredns/templates/poddisruptionbudget.yaml
+++ b/charts/coredns/templates/poddisruptionbudget.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.podDisruptionBudget -}}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+spec:
+  selector:
+    matchLabels:
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        {{- if .Values.isClusterService }}
+        k8s-app: {{ .Chart.Name | quote }}
+        {{- end }}
+        app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{ toYaml .Values.podDisruptionBudget | indent 2 }}
+{{- end }}

--- a/charts/coredns/templates/podsecuritypolicy.yaml
+++ b/charts/coredns/templates/podsecuritypolicy.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.rbac.pspEnable }}
+{{ if .Capabilities.APIVersions.Has "policy/v1beta1" }}
+apiVersion: policy/v1beta1
+{{ else }}
+apiVersion: extensions/v1beta1
+{{ end -}}
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- else }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+    {{- end }}
+spec:
+  privileged: false
+  # Required to prevent escalations to root.
+  allowPrivilegeEscalation: false
+  # Add back CAP_NET_BIND_SERVICE so that coredns can run on port 53
+  allowedCapabilities:
+  - CAP_NET_BIND_SERVICE
+    # Allow core volume types.
+  volumes:
+    - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    # Require the container to run without root privileges.
+    rule: 'RunAsAny'
+  seLinux:
+    # This policy assumes the nodes are using AppArmor rather than SELinux.
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      # Forbid adding the root group.
+      - min: 1
+        max: 65535
+  readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/coredns/templates/service-metrics.yaml
+++ b/charts/coredns/templates/service-metrics.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.prometheus.service.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "coredns.fullname" . }}-metrics
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+    app.kubernetes.io/component: metrics
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+  annotations:
+{{ toYaml .Values.prometheus.service.annotations | indent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  ports:
+  - name: metrics
+    port: 9153
+    targetPort: 9153
+{{- end }}

--- a/charts/coredns/templates/service.yaml
+++ b/charts/coredns/templates/service.yaml
@@ -1,0 +1,42 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+spec:
+  selector:
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+  {{- if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.service.externalIPs }}
+  externalIPs:
+  {{ toYaml .Values.service.externalIPs | indent 4 }}
+  {{- end }}
+  {{- if .Values.service.externalTrafficPolicy }}
+  externalTrafficPolicy: {{ .Values.service.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{- end }}
+  ports:
+{{ include "coredns.servicePorts" . | indent 2 -}}
+  type: {{ default "ClusterIP" .Values.serviceType }}

--- a/charts/coredns/templates/serviceaccount-autoscaler.yaml
+++ b/charts/coredns/templates/serviceaccount-autoscaler.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.autoscaler.enabled .Values.rbac.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "coredns.fullname" . }}-autoscaler
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name }}-autoscaler
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}-autoscaler
+{{- if .Values.customLabels }}
+{{ toYaml .Values.customLabels | indent 4 }}
+{{- end }}
+{{- end }}

--- a/charts/coredns/templates/serviceaccount.yaml
+++ b/charts/coredns/templates/serviceaccount.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "coredns.serviceAccountName" . }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+{{- end }}

--- a/charts/coredns/templates/servicemonitor.yaml
+++ b/charts/coredns/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.prometheus.monitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "coredns.fullname" . }}
+  {{- if .Values.prometheus.monitor.namespace }}
+  namespace: {{ .Values.prometheus.monitor.namespace }}
+  {{- end }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    {{- if .Values.isClusterService }}
+    k8s-app: {{ .Chart.Name | quote }}
+    kubernetes.io/cluster-service: "true"
+    kubernetes.io/name: "CoreDNS"
+    {{- end }}
+    app.kubernetes.io/name: {{ template "coredns.name" . }}
+    {{- if .Values.prometheus.monitor.additionalLabels }}
+{{ toYaml .Values.prometheus.monitor.additionalLabels | indent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name | quote }}
+      {{- if .Values.isClusterService }}
+      k8s-app: {{ .Chart.Name | quote }}
+      {{- end }}
+      app.kubernetes.io/name: {{ template "coredns.name" . }}
+      app.kubernetes.io/component: metrics
+  endpoints:
+    - port: metrics
+{{- end }}

--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -1,0 +1,255 @@
+# Default values for coredns.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  repository: coredns/coredns
+  tag: "1.8.0"
+  pullPolicy: IfNotPresent
+
+replicaCount: 1
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 100m
+    memory: 128Mi
+
+## Create HorizontalPodAutoscaler object.
+##
+# autoscaling:
+#   minReplicas: 1
+#   maxReplicas: 10
+#   metrics:
+#   - type: Resource
+#     resource:
+#       name: cpu
+#       targetAverageUtilization: 60
+#   - type: Resource
+#     resource:
+#       name: memory
+#       targetAverageUtilization: 60
+
+rollingUpdate:
+  maxUnavailable: 1
+  maxSurge: 25%
+
+# Under heavy load it takes more that standard time to remove Pod endpoint from a cluster.
+# This will delay termination of our pod by `preStopSleep`. To make sure kube-proxy has
+# enough time to catch up.
+# preStopSleep: 5
+terminationGracePeriodSeconds: 30
+
+podAnnotations: {}
+#  cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+
+serviceType: "ClusterIP"
+
+prometheus:
+  service:
+    enabled: false
+    annotations:
+      prometheus.io/scrape: "true"
+      prometheus.io/port: "9153"
+  monitor:
+    enabled: false
+    additionalLabels: {}
+    namespace: ""
+
+service:
+# clusterIP: ""
+# loadBalancerIP: ""
+# externalIPs: []
+# externalTrafficPolicy: ""
+  annotations: {}
+
+serviceAccount:
+  create: false
+  # The name of the ServiceAccount to use
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+rbac:
+  # If true, create & use RBAC resources
+  create: true
+  # If true, create and use PodSecurityPolicy
+  pspEnable: false
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # name:
+
+# isClusterService specifies whether chart should be deployed as cluster-service or normal k8s app.
+isClusterService: true
+
+# Optional priority class to be used for the coredns pods. Used for autoscaler if autoscaler.priorityClassName not set.
+priorityClassName: ""
+
+# Default zone is what Kubernetes recommends:
+# https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/#coredns-configmap-options
+servers:
+- zones:
+  - zone: .
+  port: 53
+  plugins:
+  - name: errors
+  # Serves a /health endpoint on :8080, required for livenessProbe
+  - name: health
+    configBlock: |-
+      lameduck 5s
+  # Serves a /ready endpoint on :8181, required for readinessProbe
+  - name: ready
+  # Required to query kubernetes API for data
+  - name: kubernetes
+    parameters: cluster.local in-addr.arpa ip6.arpa
+    configBlock: |-
+      pods insecure
+      fallthrough in-addr.arpa ip6.arpa
+      ttl 30
+  # Serves a /metrics endpoint on :9153, required for serviceMonitor
+  - name: prometheus
+    parameters: 0.0.0.0:9153
+  - name: forward
+    parameters: . /etc/resolv.conf
+  - name: cache
+    parameters: 30
+  - name: loop
+  - name: reload
+  - name: loadbalance
+
+# Complete example with all the options:
+# - zones:                 # the `zones` block can be left out entirely, defaults to "."
+#   - zone: hello.world.   # optional, defaults to "."
+#     scheme: tls://       # optional, defaults to "" (which equals "dns://" in CoreDNS)
+#   - zone: foo.bar.
+#     scheme: dns://
+#     use_tcp: true        # set this parameter to optionally expose the port on tcp as well as udp for the DNS protocol
+#                          # Note that this will not work if you are also exposing tls or grpc on the same server
+#   port: 12345            # optional, defaults to "" (which equals 53 in CoreDNS)
+#   plugins:               # the plugins to use for this server block
+#   - name: kubernetes     # name of plugin, if used multiple times ensure that the plugin supports it!
+#     parameters: foo bar  # list of parameters after the plugin
+#     configBlock: |-      # if the plugin supports extra block style config, supply it here
+#       hello world
+#       foo bar
+
+# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+# for example:
+#   affinity:
+#     nodeAffinity:
+#      requiredDuringSchedulingIgnoredDuringExecution:
+#        nodeSelectorTerms:
+#        - matchExpressions:
+#          - key: foo.bar.com/role
+#            operator: In
+#            values:
+#            - master
+affinity: {}
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+nodeSelector: {}
+
+# expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+# for example:
+#   tolerations:
+#   - key: foo.bar.com/role
+#     operator: Equal
+#     value: master
+#     effect: NoSchedule
+tolerations: []
+
+# https://kubernetes.io/docs/tasks/run-application/configure-pdb/#specifying-a-poddisruptionbudget
+podDisruptionBudget: {}
+
+# configure custom zone files as per https://coredns.io/2017/05/08/custom-dns-entries-for-kubernetes/
+zoneFiles: []
+#  - filename: example.db
+#    domain: example.com
+#    contents: |
+#      example.com.   IN SOA sns.dns.icann.com. noc.dns.icann.com. 2015082541 7200 3600 1209600 3600
+#      example.com.   IN NS  b.iana-servers.net.
+#      example.com.   IN NS  a.iana-servers.net.
+#      example.com.   IN A   192.168.99.102
+#      *.example.com. IN A   192.168.99.102
+
+# optional array of extra volumes to create
+extraVolumes: []
+# - name: some-volume-name
+#   emptyDir: {}
+# optional array of mount points for extraVolumes
+extraVolumeMounts: []
+# - name: some-volume-name
+#   mountPath: /etc/wherever
+
+# optional array of secrets to mount inside coredns container
+# possible usecase: need for secure connection with etcd backend
+extraSecrets: []
+# - name: etcd-client-certs
+#   mountPath: /etc/coredns/tls/etcd
+# - name: some-fancy-secret
+#   mountPath: /etc/wherever
+
+# Custom labels to apply to Deployment, Pod, Service, ServiceMonitor. Including autoscaler if enabled.
+customLabels: {}
+
+## Alternative configuration for HPA deployment if wanted
+#
+hpa:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 2
+  metrics: {}
+
+## Configue a cluster-proportional-autoscaler for coredns
+# See https://github.com/kubernetes-incubator/cluster-proportional-autoscaler
+autoscaler:
+  # Enabled the cluster-proportional-autoscaler
+  enabled: false
+
+  # Number of cores in the cluster per coredns replica
+  coresPerReplica: 256
+  # Number of nodes in the cluster per coredns replica
+  nodesPerReplica: 16
+  # Min size of replicaCount
+  min: 0
+  # Max size of replicaCount (default of 0 is no max)
+  max: 0
+  # Whether to include unschedulable nodes in the nodes/cores calculations - this requires version 1.8.0+ of the autoscaler
+  includeUnschedulableNodes: false
+  # If true does not allow single points of failure to form
+  preventSinglePointFailure: true
+
+  image:
+    repository: k8s.gcr.io/cluster-proportional-autoscaler-amd64
+    tag: "1.8.0"
+    pullPolicy: IfNotPresent
+
+  # Optional priority class to be used for the autoscaler pods. priorityClassName used if not set.
+  priorityClassName: ""
+
+  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core
+  affinity: {}
+
+  # Node labels for pod assignment
+  # Ref: https://kubernetes.io/docs/user-guide/node-selection/
+  nodeSelector: {}
+
+  # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#toleration-v1-core
+  tolerations: []
+
+  # resources for autoscaler pod
+  resources:
+    requests:
+      cpu: "20m"
+      memory: "10Mi"
+    limits:
+      cpu: "20m"
+      memory: "10Mi"
+
+  # Options for autoscaler configmap
+  configmap:
+    ## Annotations for the coredns-autoscaler configmap
+    # i.e. strategy.spinnaker.io/versioned: "false" to ensure configmap isn't renamed
+    annotations: {}


### PR DESCRIPTION
This PR will migrate upstream helm [chart](https://github.com/helm/charts) from upstream repo. It's using github pages/actions to generate helm releases Repository can be added to local helm with `helm repo add` command. 

This will also require manually creating gh-pages branch where index.yaml can be added after each build. Released helm chart will be uploaded to releases. Helm chart it self is a copy of upstream, as both repositories were using Apache license it should be compatible.

This fixes: #240
