### PR TITLE
Bump coredns -> 1.8.3, k8s -> 1.20.2, and kind -> 0.10.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,9 @@ integrationDefaults: &integrationDefaults
     image: ubuntu-1604:201903-01
   working_directory: ~/go/src/${CIRCLE_PROJECT_USERNAME}/deployment
   environment:
-    - K8S_VERSION: v1.18.2
+    - K8S_VERSION: v1.20.2
     - KUBECONFIG: /home/circleci/.kube/kind-config-kind
-    - KIND_VERSION: v0.8.1
+    - KIND_VERSION: v0.10.0
 
 setupKubernetes: &setupKubernetes
   - run:
@@ -51,6 +51,7 @@ jobs:
           name: Run Kubernetes deployment tests
           command: |
             cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/ci/test/k8sdeployment
+            go mod download
             GO111MODULE=on go test -v ./...
 
 workflows:

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -14,14 +14,19 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - endpoints
-  - endpointslices
-  - services
-  - pods
-  - namespaces
+    - endpoints
+    - services
+    - pods
+    - namespaces
   verbs:
-  - list
-  - watch
+    - list
+    - watch
+  - discovery.k8s.io
+  resources:
+    - endpointslices
+  verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -12,22 +12,22 @@ metadata:
   name: system:coredns
 rules:
   - apiGroups:
-     - ""
-     resources:
-     - endpoints
-     - services
-     - pods
-     - namespaces
-     verbs:
-     - list
-     - watch
-   - apiGroups:
-     - discovery.k8s.io
-     resources:
-     - endpointslices
-     verbs:
-     - list
-     - watch
+    - ""
+    resources:
+    - endpoints
+    - services
+    - pods
+    - namespaces
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - list
+    - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -11,22 +11,23 @@ metadata:
     kubernetes.io/bootstrapping: rbac-defaults
   name: system:coredns
 rules:
-- apiGroups:
-  - ""
-  resources:
-    - endpoints
-    - services
-    - pods
-    - namespaces
-  verbs:
-    - list
-    - watch
-  - discovery.k8s.io
-  resources:
-    - endpointslices
-  verbs:
-    - list
-    - watch
+  - apiGroups:
+     - ""
+     resources:
+     - endpoints
+     - services
+     - pods
+     - namespaces
+     verbs:
+     - list
+     - watch
+   - apiGroups:
+     - discovery.k8s.io
+     resources:
+     - endpointslices
+     verbs:
+     - list
+     - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -15,6 +15,7 @@ rules:
   - ""
   resources:
   - endpoints
+  - endpointslices
   - services
   - pods
   - namespaces
@@ -109,7 +110,7 @@ spec:
                topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: coredns/coredns:1.8.0
+        image: coredns/coredns:1.8.3
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
Bump coredns -> 1.8.3, k8s -> 1.20.2, and kind -> 0.10.0
Also add manual module download in circle ci test (required in go 1.16+).

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>