### PR TITLE
Fix go.sum rebuild in test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
           name: Run Kubernetes deployment tests
           command: |
             cd ~/go/src/${CIRCLE_PROJECT_USERNAME}/ci/test/k8sdeployment
-            go mod download
+            go mod tidy
             GO111MODULE=on go test -v ./...
 
 workflows:


### PR DESCRIPTION
Fix go.sum rebuild in integration test: use `go mod tidy` instead of `go mod download`.