### PR TITLE
HOLD: Remove kubernetes.io/cluster-service label

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -180,7 +180,6 @@ metadata:
     prometheus.io/scrape: "true"
   labels:
     k8s-app: kube-dns
-    kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
 spec:
   selector:


### PR DESCRIPTION
`kubernetes.io/cluster-service` used to be used by add-on manager, but was deprecated 5 years ago.  

Related: https://github.com/coredns/helm/issues/37