### PR TITLE
preferred cause single node failure of coredns

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -105,15 +105,13 @@ spec:
         kubernetes.io/os: linux
       affinity:
          podAntiAffinity:
-           preferredDuringSchedulingIgnoredDuringExecution:
-           - weight: 100
-             podAffinityTerm:
-               labelSelector:
-                 matchExpressions:
-                   - key: k8s-app
-                     operator: In
-                     values: ["kube-dns"]
-               topologyKey: kubernetes.io/hostname
+           requiredDuringSchedulingIgnoredDuringExecution:
+           - labelSelector:
+               matchExpressions:
+               - key: k8s-app
+                 operator: In
+                 values: ["kube-dns"]
+             topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
         image: coredns/coredns:1.8.6


### PR DESCRIPTION
preferredDuringSchedulingIgnoredDuringExecution cause single node failure in mostly deployment when increasing node one by one by cluster. In most deployment, when one node running coredns is lost, coredns service is outage at least 5mins.Suggest to use **requiredDuringSchedulingIgnoredDuringExecution** instead to avoid single node failure issue.