### PR TITLE
fix circle-ci failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,7 @@ initWorkingDir: &initWorkingDir
     GOROOT=$(go env GOROOT)
     sudo rm -r $(go env GOROOT)
     sudo mkdir $GOROOT
-    LATEST=$(curl -s https://golang.org/VERSION?m=text)
+    LATEST=$(curl -s https://go.dev/VERSION?m=text)
     curl https://dl.google.com/go/${LATEST}.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
 
 integrationDefaults: &integrationDefaults


### PR DESCRIPTION
use alternate url for curl download of go