### PR TITLE
Kubernetes: Bump CoreDNS to 1.9.1

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -114,7 +114,7 @@ spec:
              topologyKey: kubernetes.io/hostname
       containers:
       - name: coredns
-        image: coredns/coredns:1.9.0
+        image: coredns/coredns:1.9.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION

Signed-off-by: Chris O'Haver <cohaver@infoblox.com>