### PR TITLE
Package dh-systemd only in old releases. Fixes #269

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
 Source: coredns
 Maintainer: Miek Gieben <miek@coredns.io>
-Build-Depends: debhelper (>= 9), ca-certificates, curl, dh-systemd, lsb-release, jq
+Build-Depends: debhelper (>= 9), ca-certificates, curl, base-files (>= 11.1~) | dh-systemd, lsb-release, jq
 
 Package: coredns
 Architecture: any


### PR DESCRIPTION
Signed-off-by: Malware Utkonos <utkonos@malwarolo.gy>

## Description

The package `dh-systemd` is a transitional package and is not needed in newer releases. It does not exist in debian/bullseye, debian/bookworm, ubuntu/impish, or ubuntu/jammy. The following question on AskUbuntu demonstrates a trick using the version for the package `base-files` to determine the release of Debian or Ubuntu.

https://askubuntu.com/questions/760853/how-can-i-create-a-debian-control-file-that-differs-based-on-ubuntu-release

Here are the versions used to determine that `>= 11.1~` is correct:

| Release | base-files | dh-systemd |
| ------------- | ------------- | ------------- |
| Buster | 10.3+deb10u12 | Yes |
| Focal | 11ubuntu5 | Yes |
| Focal-Updates | 11ubuntu5.5 | Yes |
| Hirsute | 11ubuntu19 | No |
| Bullseye | 11.1+deb11u3 | No |
| Impish | 11.1ubuntu5 | No |
| Bookworm | 12.2 | No |
| Jammy | 12ubuntu4 | No |

Hirsute was EOL on January 20, 2022, so it is not relevant. It is included for reference only.

## Data sources

https://packages.ubuntu.com/focal/dh-systemd

https://packages.debian.org/buster/dh-systemd

https://packages.ubuntu.com/jammy/base-files

https://packages.debian.org/sid/base-files