### PR TITLE
Set recommended control fields: Section and Priority. Fixes #256

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,5 +4,7 @@ Build-Depends: debhelper (>= 9), ca-certificates, curl, dh-systemd, lsb-release,
 
 Package: coredns
 Architecture: any
+Section: net
+Priority: optional
 Description: DNS server that chains plugins
 Depends: adduser


### PR DESCRIPTION
Signed-off-by: Malware Utkonos <utkonos@malwarolo.gy>

The two fields missing from the general paragraph in the Debian control file were Section and Priority. The Section is set to "net" because this is where all other DNS servers are located in Debian's package repository. The Priority is set to "optional" according to the control file policy documentation.

## Information

https://www.debian.org/doc/debian-policy/ch-controlfields.html#source-package-control-files-debian-control

https://www.debian.org/doc/debian-policy/ch-archive.html#s-subsections

https://packages.debian.org/unstable/

https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-priority

https://www.debian.org/doc/debian-policy/ch-archive.html#s-priorities

## Additional Fix

In addition to the issue that this PR fixes, in Ubuntu 22.04 LTS, a new, repeated warning occurs during the build process due to the Section field being missing. Once this field is set, the `Use of uninitialized value` dissapears from the build output.

```
$ dpkg-buildpackage -us -uc -b
dpkg-buildpackage: info: source package coredns
dpkg-buildpackage: info: source version 0-0
dpkg-buildpackage: info: source distribution UNRELEASED
dpkg-buildpackage: info: source changed by Miek Gieben <miek@coredns.io>
dpkg-buildpackage: info: host architecture amd64
 dpkg-source --before-build .
 fakeroot debian/rules clean
dh_clean
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
dh clean --with systemd
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_clean
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
 debian/rules build
dh_clean
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
dh build --with systemd
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_update_autotools_config
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_autoreconf
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_auto_configure
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   create-stamp debian/debhelper-build-stamp
 fakeroot debian/rules binary
dh_clean
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
dh binary --with systemd
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_update_autotools_config
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_autoreconf
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_auto_configure
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   create-stamp debian/debhelper-build-stamp
   dh_testroot
   dh_prep
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   debian/rules override_dh_auto_install
make[1]: Entering directory '/home/ubuntu/test/deployment'
if [ ! -e coredns_1.9.1_linux_amd64.tgz ]; then curl -L https://github.com/coredns/coredns/releases/download/v1.9.1/coredns_1.9.1_linux_amd64.tgz -o coredns_1.9.1_linux_amd64.tgz; fi
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   666  100   666    0     0   4386      0 --:--:-- --:--:-- --:--:--  4410
100 13.2M  100 13.2M    0     0  29.1M      0 --:--:-- --:--:-- --:--:-- 51.0M
if [ ! -e v1.9.1.tar.gz ]; then  curl -L https://github.com/coredns/coredns/archive/v1.9.1.tar.gz -o v1.9.1.tar.gz; fi
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   133  100   133    0     0    888      0 --:--:-- --:--:-- --:--:--   892
100  584k    0  584k    0     0  1433k      0 --:--:-- --:--:-- --:--:-- 1433k
mkdir -p debian/coredns/usr/bin debian/coredns/etc/coredns
mkdir -p debian/man v1.9.1
tar -xf coredns_1.9.1_linux_amd64.tgz -C debian/coredns/usr/bin
tar -xf v1.9.1.tar.gz -C v1.9.1
cp v1.9.1/coredns-1.9.1/man/* debian/man/
cp debian/Corefile debian/coredns/etc/coredns/Corefile
make[1]: Leaving directory '/home/ubuntu/test/deployment'
   dh_installdocs
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_installchangelogs
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_installman
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_systemd_enable
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_installinit
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_systemd_start
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_perl
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_link
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_strip_nondeterminism
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_compress
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_fixperms
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_missing
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   debian/rules override_dh_strip
make[1]: Entering directory '/home/ubuntu/test/deployment'
# don't perform dh_strip
echo dh_strip
dh_strip
make[1]: Leaving directory '/home/ubuntu/test/deployment'
   dh_makeshlibs
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_shlibdeps
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_installdeb
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   debian/rules override_dh_gencontrol
make[1]: Entering directory '/home/ubuntu/test/deployment'
dh_gencontrol -- -v1.9.1-0~22.040
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
make[1]: Leaving directory '/home/ubuntu/test/deployment'
   dh_md5sums
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
   dh_builddeb
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1752, <$fd> line 8.
Use of uninitialized value $v in substitution (s///) at /usr/share/perl5/Debian/Debhelper/Dh_Lib.pm line 1753, <$fd> line 8.
dpkg-deb: building package 'coredns' in '../coredns_1.9.1-0~22.040_amd64.deb'.
 dpkg-genbuildinfo --build=binary -O../coredns_0-0_amd64.buildinfo
 dpkg-genchanges --build=binary -O../coredns_0-0_amd64.changes
dpkg-genchanges: warning: missing Section for binary package coredns; using '-'
dpkg-genchanges: warning: missing Priority for binary package coredns; using '-'
dpkg-genchanges: info: binary-only upload (no source code included)
 dpkg-source --after-build .
dpkg-buildpackage: info: binary-only upload (no source included)
```