### PR TITLE
feat(labels): adding standard labels to k8s deployment and service

### DIFF
--- a/kubernetes/coredns.yaml.sed
+++ b/kubernetes/coredns.yaml.sed
@@ -80,6 +80,7 @@ metadata:
   labels:
     k8s-app: kube-dns
     kubernetes.io/name: "CoreDNS"
+    app.kubernetes.io/name: coredns
 spec:
   # replicas: not specified here:
   # 1. Default is 1.
@@ -91,10 +92,12 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
+      app.kubernetes.io/name: coredns
   template:
     metadata:
       labels:
         k8s-app: kube-dns
+        app.kubernetes.io/name: coredns
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns
@@ -180,9 +183,11 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
+    app.kubernetes.io/name: coredns
 spec:
   selector:
     k8s-app: kube-dns
+    app.kubernetes.io/name: coredns
   clusterIP: CLUSTER_DNS_IP
   ports:
   - name: dns


### PR DESCRIPTION
What this PR does / why we need it:
 - Kubernetes recommends [some standard labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/), coreDNS helm chart added them [4 years ago](https://github.com/coredns/helm/commit/34c7cb523ddc6150cd2cca406b583aa13bf5dd5c). 

 - Following [coredns chart](https://github.com/coredns/helm/blob/0dbb02cedec3851e19031cde10f63901bbaf64bb/charts/coredns/templates/service.yaml#L16), this deployment should have at least the `app.kubernetes.io/name` one and then we should add it in the kubeadm static manifest

 - Related to https://github.com/kubernetes/kubernetes/pull/113433#issuecomment-1297952514

Not sure if we want to update the label selectors due to the upgrade path. In the helm chart, it was updated as well. 

---

Our use-case:
> In our use case, we leverage `app.kubernetes.io/name` label to discriminate between the different technology exposing Prometheus metrics auto-discovered in the cluster.
Since metrics scraped can be colliding (think for example to all the go_, process_ ones) or simply not being correctly namespaced it is complex to build dashboards without relying on a standard label such `app.kubernetes.io/name`.
