### PR TITLE
Updating this chart to include Kubernetes 1.25 and CoreDNS 1.9.3

### DIFF
--- a/kubernetes/CoreDNS-k8s_version.md
+++ b/kubernetes/CoreDNS-k8s_version.md
@@ -5,6 +5,7 @@ This document records the CoreDNS version that was installed by kubeadm with eac
 
 | Kubernetes Version |      CoreDNS version installed by kubeadm      |  Changes in CoreDNS from previous release to Kubernetes |
 |:------------------:|:-------------------------:|:----------|
+|       v1.25        | [v1.9.3](https://github.com/coredns/coredns/releases/tag/v1.9.3) | |
 |       v1.24        |  [v1.8.6](https://github.com/coredns/coredns/releases/tag/v1.8.6) |  |
 |       v1.23        |  [v1.8.6](https://github.com/coredns/coredns/releases/tag/v1.8.6) | https://github.com/coredns/coredns/blob/master/notes/coredns-1.8.5.md <br>https://github.com/coredns/coredns/blob/master/notes/coredns-1.8.6.md |
 |       v1.22        |  [v1.8.4](https://github.com/coredns/coredns/releases/tag/v1.8.4) | https://github.com/coredns/coredns/blob/master/notes/coredns-1.8.1.md <br>https://github.com/coredns/coredns/blob/master/notes/coredns-1.8.2.md <br>https://github.com/coredns/coredns/blob/master/notes/coredns-1.8.3.md <br>https://github.com/coredns/coredns/blob/master/notes/coredns-1.8.4.md <br><br> ***---NOTE---*** CoreDNS must be granted list and watch access to EndpointSlices |


### PR DESCRIPTION
Updating this chart to include the version of CoreDNS installed by kubeadm for Kubernetes 1.25

Signed-off-by: Jay Beale <jay.beale@gmail.com>