### PR TITLE
systemd sandboxing

### DIFF
--- a/systemd/coredns-sysusers.conf
+++ b/systemd/coredns-sysusers.conf
@@ -1,1 +1,1 @@
-u coredns - "CoreDNS is a DNS server that chains plugins" /var/lib/coredns
+g coredns

--- a/systemd/coredns-tmpfiles.conf
+++ b/systemd/coredns-tmpfiles.conf
@@ -1,1 +1,0 @@
-d /var/lib/coredns 0755 coredns coredns -

--- a/systemd/coredns.service
+++ b/systemd/coredns.service
@@ -1,17 +1,42 @@
+# Thanks to: acassen/keepalived/blob/master/keepalived/keepalived-non-root.service.in
+
 [Unit]
 Description=CoreDNS DNS server
 Documentation=https://coredns.io
 After=network.target
 
 [Service]
-PermissionsStartOnly=true
+LockPersonality=yes
+NoNewPrivileges=yes
+DynamicUser=yes
+RemoveIPC=yes
+ProtectSystem=strict
+ProtectHome=read-only
+ProtectClock=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectKernelLogs=yes
+ProtectControlGroups=yes
+ProtectHostname=yes
+DevicePolicy=strict
+DeviceAllow=/dev/null
+PrivateMounts=yes
+PrivateNetwork=no
+PrivateTmp=yes
+PrivateIPC=yes
+StateDirectory=%N
+StateDirectoryMode=0750
+WorkingDirectory=/var/lib/%N
+UMask=0007
+User=_%N
+Group=%N
 LimitNOFILE=1048576
 LimitNPROC=512
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 AmbientCapabilities=CAP_NET_BIND_SERVICE
-NoNewPrivileges=true
-User=coredns
-WorkingDirectory=~
+RestrictNamespaces=yes
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+KillSignal=SIGTERM
 ExecStart=/usr/bin/coredns -conf=/etc/coredns/Corefile
 ExecReload=/bin/kill -SIGUSR1 $MAINPID
 Restart=on-failure


### PR DESCRIPTION
Hi all, I hope this PR will be helpful and appreciated.

I needed to run ```coredns``` with systemd and I noticed that we can try to sandboxing it a bit more; I ran this step in my environment for a while with different plugins with no issues.

The new  ```coredns``` systemd unit file is partially based on [acassen/keepalived/blob/master/keepalived/keepalived-non-root.service.in](https://github.com/acassen/keepalived/blob/7fc73615d3dc916282af4fe5ec620e97c09b3701/keepalived/keepalived-non-root.service.in) with some additional restrictions and customizations.

Please, let me know if you want me to detail this patch a bit more.