### PR TITLE
Add Kubernetes 1.29 and 1.30

### DIFF
--- a/kubernetes/CoreDNS-k8s_version.md
+++ b/kubernetes/CoreDNS-k8s_version.md
@@ -5,6 +5,8 @@ This document records the CoreDNS version that was installed by kubeadm with eac
 
 | Kubernetes Version |      CoreDNS version installed by kubeadm      |  Changes in CoreDNS from previous release to Kubernetes |
 |:------------------:|:-------------------------:|:----------|
+|       v1.30        | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | |
+|       v1.29        | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | |
 |       v1.28        | [v1.10.1](https://github.com/coredns/coredns/releases/tag/v1.10.1) | |
 |       v1.27        | [v1.10.1](https://github.com/coredns/coredns/releases/tag/v1.10.1) | |
 |       v1.26        | [v1.9.3](https://github.com/coredns/coredns/releases/tag/v1.9.3) | |


### PR DESCRIPTION
As per https://github.com/kubernetes/kubernetes/pull/120116 Kubernetes 1.29 supports CoreDNS v1.11.1