### PR TITLE
bump ubuntu to 2204

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ initWorkingDir: &initWorkingDir
 
 integrationDefaults: &integrationDefaults
   machine:
-    image: ubuntu-1604:201903-01
+    image: ubuntu-2204:2024.05.1
   working_directory: ~/go/src/${CIRCLE_PROJECT_USERNAME}/deployment
   environment:
     - K8S_VERSION: v1.22.0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,11 +10,11 @@ initWorkingDir: &initWorkingDir
     mkdir -p ~/go/out/tests
     mkdir -p ~/go/out/logs
     mkdir -p /home/circleci/logs
-    GOROOT=$(go env GOROOT)
-    sudo rm -r $(go env GOROOT)
-    sudo mkdir $GOROOT
-    LATEST=$(curl -s https://go.dev/VERSION?m=text)
-    curl https://dl.google.com/go/${LATEST}.linux-amd64.tar.gz | sudo tar xz -C $GOROOT --strip-components=1
+    sudo rm -r /usr/local/go
+    sudo mkdir -p /usr/local/go
+    LATEST=$(curl -s https://go.dev/VERSION?m=text | head -n 1)
+    sudo wget https://go.dev/dl/${LATEST}.linux-amd64.tar.gz -O go.tar.gz
+    sudo tar -xzvf go.tar.gz -C /usr/local
 
 integrationDefaults: &integrationDefaults
   machine:


### PR DESCRIPTION
- image ubuntu-1604:201903-01 is not a valid resource class

https://app.circleci.com/pipelines/github/coredns/deployment/167/workflows/54743828-9787-4b62-813b-192f0ddd9064/jobs/166/release-insights