### PR TITLE
Add Kubernetes 1.32

### DIFF
--- a/kubernetes/CoreDNS-k8s_version.md
+++ b/kubernetes/CoreDNS-k8s_version.md
@@ -5,6 +5,7 @@ This document records the CoreDNS version that was installed by kubeadm with eac
 
 | Kubernetes Version |      CoreDNS version installed by kubeadm      |  Changes in CoreDNS from previous release to Kubernetes |
 |:------------------:|:-------------------------:|:----------|
+|       v1.32        | [v1.11.3](https://github.com/coredns/coredns/releases/tag/v1.11.3) | |
 |       v1.31        | [v1.11.3](https://github.com/coredns/coredns/releases/tag/v1.11.3) | |
 |       v1.30        | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | |
 |       v1.29        | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | |


### PR DESCRIPTION
related: https://github.com/coredns/deployment/pull/301

kubeadm v1.32 still uses coredns v1.11.3 same as v1.31.

https://github.com/kubernetes/kubernetes/blob/70d3cc986aa8221cd1dfb1121852688902d3bf53/build/dependencies.yaml#L32-L47