### PR TITLE
Add Kubernetes 1.33

### DIFF
--- a/kubernetes/CoreDNS-k8s_version.md
+++ b/kubernetes/CoreDNS-k8s_version.md
@@ -5,6 +5,7 @@ This document records the CoreDNS version that was installed by kubeadm with eac
 
 | Kubernetes Version |      CoreDNS version installed by kubeadm      |  Changes in CoreDNS from previous release to Kubernetes |
 |:------------------:|:-------------------------:|:----------|
+|       v1.33        | [v1.12.0](https://github.com/coredns/coredns/releases/tag/v1.12.0) | |
 |       v1.32        | [v1.11.3](https://github.com/coredns/coredns/releases/tag/v1.11.3) | |
 |       v1.31        | [v1.11.3](https://github.com/coredns/coredns/releases/tag/v1.11.3) | |
 |       v1.30        | [v1.11.1](https://github.com/coredns/coredns/releases/tag/v1.11.1) | |


### PR DESCRIPTION
kubeadm v1.33 has started using coredns v1.12.0.

https://github.com/kubernetes/kubernetes/blob/v1.33.0/build/dependencies.yaml#L32-L47